### PR TITLE
Add export command (SQLite -> HAR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/target/
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+*.har

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "clap",
  "indicatif",
  "predicates",
+ "regex",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1"
 blake3 = "1"
 indicatif = "0.17"
 base64 = "0.22"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,44 @@ harlite info traffic.db
 #   Stored blobs: 156 (12.4 MB)
 ```
 
+### Export HAR files
+
+Export a `harlite` SQLite database back to HAR format (optionally with bodies if they were stored during import):
+
+```bash
+# Export all entries (pretty-printed by default)
+harlite export traffic.db -o traffic.har
+
+# Export to stdout
+harlite export traffic.db -o -
+
+# Include stored request/response bodies (if present in the DB)
+harlite export traffic.db --bodies -o traffic-with-bodies.har
+
+# Compact JSON
+harlite export traffic.db --compact -o traffic.min.har
+
+# Filter examples
+harlite export traffic.db --host api.example.com --status 200 --method GET -o api-get-200.har
+harlite export traffic.db --url-regex 'example\\.com/(api|v1)/' -o filtered.har
+harlite export traffic.db --from 2024-01-15 --to 2024-01-16 -o day1.har
+harlite export traffic.db --ext js,css -o assets.har
+harlite export traffic.db --source session1.har --source-contains chrome -o sources.har
+harlite export traffic.db --mime json --min-response-size 1KB --max-response-size 200KB -o api-responses.har
+```
+
+Common filters:
+- `--url`, `--url-contains`, `--url-regex`
+- `--host`, `--method`, `--status`
+- `--mime` (substring match), `--ext` (file extension)
+- `--from` / `--to` (RFC3339 timestamp or `YYYY-MM-DD`)
+- `--min-request-size` / `--max-request-size`, `--min-response-size` / `--max-response-size`
+- `--source` / `--source-contains` (filters by `imports.source_file`)
+
+Notes / gaps:
+- HAR `timings` are reconstructed from the stored total duration (`time_ms`), so the breakdown is best-effort.
+- Some HAR fields are not stored in the DB (e.g. `headersSize`, response `httpVersion`), so they may be omitted or approximated on export.
+
 ## Database Schema
 
 ### `entries` table
@@ -444,7 +482,7 @@ Contributions welcome! Please open an issue to discuss major changes before subm
 
 Future possibilities (not yet implemented):
 
-- [ ] `harlite export` — Export SQLite back to HAR format
+- [x] `harlite export` — Export SQLite back to HAR format
 - [ ] `harlite query` — Built-in query command with output formatting
 - [ ] `harlite stats` — Quick summary statistics without full info
 - [ ] `harlite redact` — Remove sensitive headers/cookies before sharing

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,0 +1,564 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, NaiveDate, Utc};
+use regex::Regex;
+use rusqlite::Connection;
+use url::Url;
+
+use crate::db::{load_blobs_by_hashes, load_entries, load_pages_for_imports, BlobRow, EntryQuery};
+use crate::error::{HarliteError, Result};
+use crate::har::{
+    Content, Cookie, Creator, Entry, Har, Header, Log, Page, PageTimings, PostData, QueryParam,
+    Request, Response, Timings,
+};
+
+/// Options for exporting a harlite database back to a HAR file.
+pub struct ExportOptions {
+    pub output: Option<PathBuf>,
+    pub pretty: bool,
+    pub include_bodies: bool,
+
+    pub url: Vec<String>,
+    pub url_contains: Vec<String>,
+    pub url_regex: Vec<String>,
+
+    pub host: Vec<String>,
+    pub method: Vec<String>,
+    pub status: Vec<i32>,
+    pub mime_contains: Vec<String>,
+    pub ext: Vec<String>,
+
+    pub source: Vec<String>,
+    pub source_contains: Vec<String>,
+
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub min_request_size: Option<String>,
+    pub max_request_size: Option<String>,
+    pub min_response_size: Option<String>,
+    pub max_response_size: Option<String>,
+}
+
+impl Default for ExportOptions {
+    fn default() -> Self {
+        Self {
+            output: None,
+            pretty: true,
+            include_bodies: false,
+            url: Vec::new(),
+            url_contains: Vec::new(),
+            url_regex: Vec::new(),
+            host: Vec::new(),
+            method: Vec::new(),
+            status: Vec::new(),
+            mime_contains: Vec::new(),
+            ext: Vec::new(),
+            source: Vec::new(),
+            source_contains: Vec::new(),
+            from: None,
+            to: None,
+            min_request_size: None,
+            max_request_size: None,
+            min_response_size: None,
+            max_response_size: None,
+        }
+    }
+}
+
+fn parse_size_bytes(s: &str) -> Option<i64> {
+    let s = s.trim().to_lowercase();
+    if s.is_empty() {
+        return None;
+    }
+    if s == "unlimited" {
+        return None;
+    }
+
+    let (num, mult) = if s.ends_with("kb") {
+        (s.trim_end_matches("kb").trim(), 1024i64)
+    } else if s.ends_with("mb") {
+        (s.trim_end_matches("mb").trim(), 1024i64 * 1024)
+    } else if s.ends_with("gb") {
+        (s.trim_end_matches("gb").trim(), 1024i64 * 1024 * 1024)
+    } else {
+        (s.as_str(), 1i64)
+    };
+
+    num.parse::<i64>().ok().map(|n| n.saturating_mul(mult))
+}
+
+fn parse_started_at_bound(s: &str, is_end: bool) -> Result<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(HarliteError::InvalidHar(
+            "Empty timestamp bound".to_string(),
+        ));
+    }
+
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc).to_rfc3339());
+    }
+
+    let date = NaiveDate::parse_from_str(s, "%Y-%m-%d")?;
+    let dt = if is_end {
+        date.and_hms_opt(23, 59, 59)
+            .and_then(|d| d.and_local_timezone(Utc).single())
+            .ok_or_else(|| HarliteError::InvalidHar("Invalid end date".to_string()))?
+    } else {
+        date.and_hms_opt(0, 0, 0)
+            .and_then(|d| d.and_local_timezone(Utc).single())
+            .ok_or_else(|| HarliteError::InvalidHar("Invalid start date".to_string()))?
+    };
+    Ok(dt.to_rfc3339())
+}
+
+fn headers_from_json(json: Option<&str>) -> Vec<Header> {
+    let Some(json) = json else {
+        return Vec::new();
+    };
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Vec::new();
+    };
+    let Some(obj) = value.as_object() else {
+        return Vec::new();
+    };
+
+    let mut out: Vec<Header> = obj
+        .iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k, s)))
+        .map(|(k, v)| Header {
+            name: k.to_string(),
+            value: v.to_string(),
+        })
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn cookies_from_json(json: Option<&str>) -> Vec<Cookie> {
+    let Some(json) = json else {
+        return Vec::new();
+    };
+    serde_json::from_str::<Vec<Cookie>>(json).unwrap_or_default()
+}
+
+fn query_string_from_url(url: &str) -> Option<Vec<QueryParam>> {
+    let parsed = Url::parse(url).ok()?;
+    let mut out: Vec<QueryParam> = Vec::new();
+    for (name, value) in parsed.query_pairs() {
+        out.push(QueryParam {
+            name: name.to_string(),
+            value: value.to_string(),
+        });
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+fn url_extension(url: &str) -> Option<String> {
+    let parsed = Url::parse(url).ok()?;
+    let path = parsed.path();
+    let file = path.rsplit('/').next().unwrap_or("");
+    let ext = file.rsplit('.').next()?;
+    if ext == file {
+        return None;
+    }
+    Some(ext.to_lowercase())
+}
+
+fn request_mime_type(headers: &[Header]) -> Option<String> {
+    headers
+        .iter()
+        .find(|h| h.name.eq_ignore_ascii_case("content-type"))
+        .map(|h| {
+            h.value
+                .split(';')
+                .next()
+                .unwrap_or(&h.value)
+                .trim()
+                .to_string()
+        })
+        .filter(|s| !s.is_empty())
+}
+
+fn body_text_and_encoding(content: &[u8]) -> (Option<String>, Option<String>) {
+    if content.is_empty() {
+        return (None, None);
+    }
+    match std::str::from_utf8(content) {
+        Ok(s) => (Some(s.to_string()), None),
+        Err(_) => {
+            use base64::{engine::general_purpose::STANDARD, Engine as _};
+            (Some(STANDARD.encode(content)), Some("base64".to_string()))
+        }
+    }
+}
+
+fn page_export_id(import_id: i64, page_id: &str, multi_import: bool) -> String {
+    if multi_import {
+        format!("{import_id}:{page_id}")
+    } else {
+        page_id.to_string()
+    }
+}
+
+fn open_output(path: &Path) -> Result<Box<dyn Write>> {
+    if path == Path::new("-") {
+        return Ok(Box::new(io::stdout().lock()));
+    }
+    Ok(Box::new(BufWriter::new(File::create(path)?)))
+}
+
+fn load_import_ids_by_source(
+    conn: &Connection,
+    source: &[String],
+    source_contains: &[String],
+) -> Result<Vec<i64>> {
+    if source.is_empty() && source_contains.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut clauses: Vec<String> = Vec::new();
+    let mut params: Vec<rusqlite::types::Value> = Vec::new();
+
+    if !source.is_empty() {
+        let placeholders = std::iter::repeat("?")
+            .take(source.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        clauses.push(format!("source_file IN ({placeholders})"));
+        for s in source {
+            params.push(rusqlite::types::Value::Text(s.clone()));
+        }
+    }
+
+    if !source_contains.is_empty() {
+        let joined = std::iter::repeat("source_file LIKE '%' || ? || '%'")
+            .take(source_contains.len())
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        clauses.push(format!("({joined})"));
+        for s in source_contains {
+            params.push(rusqlite::types::Value::Text(s.clone()));
+        }
+    }
+
+    let mut sql = "SELECT id FROM imports".to_string();
+    if !clauses.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
+    let ids = stmt
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| row.get(0))?
+        .filter_map(|r| r.ok())
+        .collect::<Vec<i64>>();
+    Ok(ids)
+}
+
+/// Export a harlite SQLite database back to a HAR file.
+pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
+    let conn = Connection::open(&database)?;
+
+    let output_path = match &options.output {
+        Some(p) => p.clone(),
+        None => {
+            let stem = database
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("export");
+            PathBuf::from(format!("{stem}.har"))
+        }
+    };
+
+    let from_started_at = match options.from.as_deref() {
+        Some(s) => Some(parse_started_at_bound(s, false)?),
+        None => None,
+    };
+    let to_started_at = match options.to.as_deref() {
+        Some(s) => Some(parse_started_at_bound(s, true)?),
+        None => None,
+    };
+
+    let mut query = EntryQuery::default();
+
+    let import_ids = load_import_ids_by_source(&conn, &options.source, &options.source_contains)?;
+    if !import_ids.is_empty() {
+        query.import_ids = import_ids;
+    }
+
+    query.from_started_at = from_started_at;
+    query.to_started_at = to_started_at;
+    query.url_exact = options.url.clone();
+    query.url_contains = options.url_contains.clone();
+    query.hosts = options.host.clone();
+    query.methods = options.method.clone();
+    query.statuses = options.status.clone();
+    query.mime_contains = options.mime_contains.clone();
+    query.min_request_size = options
+        .min_request_size
+        .as_deref()
+        .and_then(parse_size_bytes);
+    query.max_request_size = options
+        .max_request_size
+        .as_deref()
+        .and_then(parse_size_bytes);
+    query.min_response_size = options
+        .min_response_size
+        .as_deref()
+        .and_then(parse_size_bytes);
+    query.max_response_size = options
+        .max_response_size
+        .as_deref()
+        .and_then(parse_size_bytes);
+
+    let mut entries = load_entries(&conn, &query)?;
+
+    let url_regexes: Vec<Regex> = options
+        .url_regex
+        .iter()
+        .map(|s| Regex::new(s))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    let exts: HashSet<String> = options
+        .ext
+        .iter()
+        .map(|s| s.trim().trim_start_matches('.').to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if !url_regexes.is_empty() || !exts.is_empty() {
+        entries.retain(|e| {
+            let Some(url) = e.url.as_deref() else {
+                return false;
+            };
+
+            if !url_regexes.is_empty() && !url_regexes.iter().any(|re| re.is_match(url)) {
+                return false;
+            }
+
+            if !exts.is_empty() {
+                let Some(ext) = url_extension(url) else {
+                    return false;
+                };
+                if !exts.contains(&ext) {
+                    return false;
+                }
+            }
+
+            true
+        });
+    }
+
+    let import_ids: Vec<i64> = {
+        let mut uniq: Vec<i64> = entries.iter().map(|e| e.import_id).collect();
+        uniq.sort_unstable();
+        uniq.dedup();
+        uniq
+    };
+    let multi_import = import_ids.len() > 1;
+
+    let pages = load_pages_for_imports(&conn, &import_ids)?;
+    let page_by_key: HashMap<(i64, String), crate::db::PageRow> = pages
+        .into_iter()
+        .map(|p| ((p.import_id, p.id.clone()), p))
+        .collect();
+
+    let mut needed_pages: HashSet<(i64, String)> = HashSet::new();
+    for e in &entries {
+        if let Some(pid) = &e.page_id {
+            needed_pages.insert((e.import_id, pid.clone()));
+        }
+    }
+
+    let mut har_pages: Vec<Page> = Vec::new();
+    for (import_id, pid) in needed_pages.iter() {
+        if let Some(p) = page_by_key.get(&(*import_id, pid.clone())) {
+            har_pages.push(Page {
+                started_date_time: p
+                    .started_at
+                    .clone()
+                    .unwrap_or_else(|| Utc::now().to_rfc3339()),
+                id: page_export_id(*import_id, &p.id, multi_import),
+                title: p.title.clone(),
+                page_timings: Some(PageTimings {
+                    on_content_load: p.on_content_load_ms,
+                    on_load: p.on_load_ms,
+                }),
+            });
+        }
+    }
+    har_pages.sort_by(|a, b| a.started_date_time.cmp(&b.started_date_time));
+
+    let mut blob_map: HashMap<String, BlobRow> = HashMap::new();
+    if options.include_bodies {
+        let mut hashes: Vec<String> = entries
+            .iter()
+            .flat_map(|e| {
+                [e.request_body_hash.as_ref(), e.response_body_hash.as_ref()]
+                    .into_iter()
+                    .flatten()
+            })
+            .cloned()
+            .collect();
+        hashes.sort();
+        hashes.dedup();
+        let blobs = load_blobs_by_hashes(&conn, &hashes)?;
+        blob_map = blobs.into_iter().map(|b| (b.hash.clone(), b)).collect();
+    }
+
+    let mut har_entries: Vec<Entry> = Vec::with_capacity(entries.len());
+    for row in entries {
+        let started = row
+            .started_at
+            .clone()
+            .unwrap_or_else(|| Utc::now().to_rfc3339());
+        let time_ms = row.time_ms.unwrap_or(0.0);
+        let url = row.url.clone().unwrap_or_default();
+
+        let request_headers = headers_from_json(row.request_headers.as_deref());
+        let response_headers = headers_from_json(row.response_headers.as_deref());
+        let request_cookies = cookies_from_json(row.request_cookies.as_deref());
+        let response_cookies = cookies_from_json(row.response_cookies.as_deref());
+
+        let mut request_body_text: Option<String> = None;
+        let mut request_body_len: Option<i64> = None;
+        if options.include_bodies {
+            if let Some(hash) = &row.request_body_hash {
+                if let Some(blob) = blob_map.get(hash) {
+                    (request_body_text, _) = body_text_and_encoding(&blob.content);
+                    request_body_len = Some(blob.content.len() as i64);
+                }
+            }
+        }
+
+        let mut response_body_text: Option<String> = None;
+        let mut response_body_encoding: Option<String> = None;
+        let mut response_body_size: i64 = row.response_body_size.unwrap_or(0);
+        let mut response_mime = row.response_mime_type.clone();
+        if options.include_bodies {
+            if let Some(hash) = &row.response_body_hash {
+                if let Some(blob) = blob_map.get(hash) {
+                    let (text, enc) = body_text_and_encoding(&blob.content);
+                    response_body_text = text;
+                    response_body_encoding = enc;
+                    response_body_size = blob.content.len() as i64;
+                    if response_mime.is_none() {
+                        response_mime = blob.mime_type.clone();
+                    }
+                }
+            }
+        }
+
+        let request_body_size = row.request_body_size.or(request_body_len);
+        let response_body_size_field = if options.include_bodies && response_body_text.is_some() {
+            Some(response_body_size)
+        } else {
+            row.response_body_size
+        };
+
+        let timings = Some(Timings {
+            blocked: None,
+            dns: None,
+            connect: None,
+            send: 0.0,
+            wait: time_ms,
+            receive: 0.0,
+            ssl: None,
+        });
+
+        let post_data = if request_body_text.is_some() {
+            Some(PostData {
+                mime_type: request_mime_type(&request_headers),
+                text: request_body_text,
+                params: None,
+            })
+        } else {
+            None
+        };
+
+        har_entries.push(Entry {
+            pageref: row
+                .page_id
+                .as_deref()
+                .map(|pid| page_export_id(row.import_id, pid, multi_import)),
+            started_date_time: started,
+            time: time_ms,
+            request: Request {
+                method: row.method.clone().unwrap_or_default(),
+                url: url.clone(),
+                http_version: row.http_version.clone().unwrap_or_default(),
+                cookies: Some(request_cookies),
+                headers: request_headers,
+                query_string: query_string_from_url(&url),
+                post_data,
+                headers_size: None,
+                body_size: request_body_size,
+            },
+            response: Response {
+                status: row.status.unwrap_or(0),
+                status_text: row.status_text.clone().unwrap_or_default(),
+                http_version: row.http_version.clone().unwrap_or_default(),
+                cookies: Some(response_cookies),
+                headers: response_headers,
+                content: Content {
+                    size: response_body_size,
+                    compression: None,
+                    mime_type: response_mime,
+                    text: response_body_text,
+                    encoding: response_body_encoding,
+                },
+                redirect_url: None,
+                headers_size: None,
+                body_size: response_body_size_field,
+            },
+            cache: None,
+            timings,
+            server_ip_address: row.server_ip.clone(),
+            connection: row.connection_id.clone(),
+        });
+    }
+
+    let har = Har {
+        log: Log {
+            version: Some("1.2".to_string()),
+            creator: Some(Creator {
+                name: "harlite".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            }),
+            browser: None,
+            pages: if har_pages.is_empty() {
+                None
+            } else {
+                Some(har_pages)
+            },
+            entries: har_entries,
+        },
+    };
+
+    let mut writer = open_output(&output_path)?;
+    if options.pretty {
+        serde_json::to_writer_pretty(&mut writer, &har)?;
+    } else {
+        serde_json::to_writer(&mut writer, &har)?;
+    }
+    writer.write_all(b"\n")?;
+
+    if output_path != PathBuf::from("-") {
+        println!(
+            "Exported {} entries to {}",
+            har.log.entries.len(),
+            output_path.display()
+        );
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,9 @@
+mod export;
 mod import;
 mod info;
 mod schema;
 
+pub use export::{run_export, ExportOptions};
 pub use import::{run_import, ImportOptions};
 pub use info::run_info;
 pub use schema::run_schema;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,7 @@
+mod reader;
 mod schema;
 mod writer;
 
+pub use reader::*;
 pub use schema::*;
 pub use writer::*;

--- a/src/db/reader.rs
+++ b/src/db/reader.rs
@@ -1,0 +1,316 @@
+use rusqlite::types::Value;
+use rusqlite::{params_from_iter, Connection};
+
+use crate::error::Result;
+
+#[derive(Debug, Clone)]
+pub struct EntryRow {
+    pub import_id: i64,
+    pub page_id: Option<String>,
+    pub started_at: Option<String>,
+    pub time_ms: Option<f64>,
+    pub method: Option<String>,
+    pub url: Option<String>,
+    pub http_version: Option<String>,
+    pub request_headers: Option<String>,
+    pub request_cookies: Option<String>,
+    pub request_body_hash: Option<String>,
+    pub request_body_size: Option<i64>,
+    pub status: Option<i32>,
+    pub status_text: Option<String>,
+    pub response_headers: Option<String>,
+    pub response_cookies: Option<String>,
+    pub response_body_hash: Option<String>,
+    pub response_body_size: Option<i64>,
+    pub response_mime_type: Option<String>,
+    pub server_ip: Option<String>,
+    pub connection_id: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct EntryQuery {
+    pub import_ids: Vec<i64>,
+    pub from_started_at: Option<String>,
+    pub to_started_at: Option<String>,
+    pub url_exact: Vec<String>,
+    pub url_contains: Vec<String>,
+    pub hosts: Vec<String>,
+    pub methods: Vec<String>,
+    pub statuses: Vec<i32>,
+    pub mime_contains: Vec<String>,
+    pub min_request_size: Option<i64>,
+    pub max_request_size: Option<i64>,
+    pub min_response_size: Option<i64>,
+    pub max_response_size: Option<i64>,
+}
+
+fn push_in_clause(
+    clauses: &mut Vec<String>,
+    params: &mut Vec<Value>,
+    column: &str,
+    values: &[String],
+) {
+    if values.is_empty() {
+        return;
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(values.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    clauses.push(format!("{column} IN ({placeholders})"));
+    for v in values {
+        params.push(Value::Text(v.clone()));
+    }
+}
+
+fn push_in_clause_i32(
+    clauses: &mut Vec<String>,
+    params: &mut Vec<Value>,
+    column: &str,
+    values: &[i32],
+) {
+    if values.is_empty() {
+        return;
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(values.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    clauses.push(format!("{column} IN ({placeholders})"));
+    for v in values {
+        params.push(Value::Integer(i64::from(*v)));
+    }
+}
+
+fn push_in_clause_i64(
+    clauses: &mut Vec<String>,
+    params: &mut Vec<Value>,
+    column: &str,
+    values: &[i64],
+) {
+    if values.is_empty() {
+        return;
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(values.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    clauses.push(format!("{column} IN ({placeholders})"));
+    for v in values {
+        params.push(Value::Integer(*v));
+    }
+}
+
+fn push_like_any(
+    clauses: &mut Vec<String>,
+    params: &mut Vec<Value>,
+    predicate: &str,
+    needles: &[String],
+) {
+    if needles.is_empty() {
+        return;
+    }
+
+    let joined = std::iter::repeat(predicate)
+        .take(needles.len())
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    clauses.push(format!("({joined})"));
+    for needle in needles {
+        params.push(Value::Text(needle.clone()));
+    }
+}
+
+pub fn load_entries(conn: &Connection, query: &EntryQuery) -> Result<Vec<EntryRow>> {
+    let mut clauses: Vec<String> = Vec::new();
+    let mut params: Vec<Value> = Vec::new();
+
+    push_in_clause_i64(&mut clauses, &mut params, "import_id", &query.import_ids);
+
+    if let Some(from) = &query.from_started_at {
+        clauses.push("started_at >= ?".to_string());
+        params.push(Value::Text(from.clone()));
+    }
+    if let Some(to) = &query.to_started_at {
+        clauses.push("started_at <= ?".to_string());
+        params.push(Value::Text(to.clone()));
+    }
+
+    push_in_clause(&mut clauses, &mut params, "url", &query.url_exact);
+    push_in_clause(&mut clauses, &mut params, "host", &query.hosts);
+    push_in_clause(&mut clauses, &mut params, "method", &query.methods);
+    push_in_clause_i32(&mut clauses, &mut params, "status", &query.statuses);
+    push_like_any(
+        &mut clauses,
+        &mut params,
+        "url LIKE '%' || ? || '%'",
+        &query.url_contains,
+    );
+    push_like_any(
+        &mut clauses,
+        &mut params,
+        "LOWER(response_mime_type) LIKE '%' || LOWER(?) || '%'",
+        &query.mime_contains,
+    );
+
+    if let Some(min) = query.min_request_size {
+        clauses.push("COALESCE(request_body_size, 0) >= ?".to_string());
+        params.push(Value::Integer(min));
+    }
+    if let Some(max) = query.max_request_size {
+        clauses.push("COALESCE(request_body_size, 0) <= ?".to_string());
+        params.push(Value::Integer(max));
+    }
+    if let Some(min) = query.min_response_size {
+        clauses.push("COALESCE(response_body_size, 0) >= ?".to_string());
+        params.push(Value::Integer(min));
+    }
+    if let Some(max) = query.max_response_size {
+        clauses.push("COALESCE(response_body_size, 0) <= ?".to_string());
+        params.push(Value::Integer(max));
+    }
+
+    let mut sql = r#"
+        SELECT
+            import_id,
+            page_id,
+            started_at,
+            time_ms,
+            method,
+            url,
+            http_version,
+            request_headers,
+            request_cookies,
+            request_body_hash,
+            request_body_size,
+            status,
+            status_text,
+            response_headers,
+            response_cookies,
+            response_body_hash,
+            response_body_size,
+            response_mime_type,
+            server_ip,
+            connection_id
+        FROM entries
+    "#
+    .to_string();
+
+    if !clauses.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+    sql.push_str(" ORDER BY started_at, id");
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+        Ok(EntryRow {
+            import_id: row.get(0)?,
+            page_id: row.get(1)?,
+            started_at: row.get(2)?,
+            time_ms: row.get(3)?,
+            method: row.get(4)?,
+            url: row.get(5)?,
+            http_version: row.get(6)?,
+            request_headers: row.get(7)?,
+            request_cookies: row.get(8)?,
+            request_body_hash: row.get(9)?,
+            request_body_size: row.get(10)?,
+            status: row.get(11)?,
+            status_text: row.get(12)?,
+            response_headers: row.get(13)?,
+            response_cookies: row.get(14)?,
+            response_body_hash: row.get(15)?,
+            response_body_size: row.get(16)?,
+            response_mime_type: row.get(17)?,
+            server_ip: row.get(18)?,
+            connection_id: row.get(19)?,
+        })
+    })?;
+
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
+#[derive(Debug, Clone)]
+pub struct PageRow {
+    pub import_id: i64,
+    pub id: String,
+    pub started_at: Option<String>,
+    pub title: Option<String>,
+    pub on_content_load_ms: Option<f64>,
+    pub on_load_ms: Option<f64>,
+}
+
+pub fn load_pages_for_imports(conn: &Connection, import_ids: &[i64]) -> Result<Vec<PageRow>> {
+    if import_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let placeholders = std::iter::repeat("?")
+        .take(import_ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let sql = format!(
+        "SELECT import_id, id, started_at, title, on_content_load_ms, on_load_ms FROM pages WHERE import_id IN ({placeholders})"
+    );
+
+    let params: Vec<Value> = import_ids
+        .iter()
+        .copied()
+        .map(|id| Value::Integer(id))
+        .collect();
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+        Ok(PageRow {
+            import_id: row.get(0)?,
+            id: row.get(1)?,
+            started_at: row.get(2)?,
+            title: row.get(3)?,
+            on_content_load_ms: row.get(4)?,
+            on_load_ms: row.get(5)?,
+        })
+    })?;
+
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
+#[derive(Debug, Clone)]
+pub struct BlobRow {
+    pub hash: String,
+    pub content: Vec<u8>,
+    pub mime_type: Option<String>,
+}
+
+pub fn load_blobs_by_hashes(conn: &Connection, hashes: &[String]) -> Result<Vec<BlobRow>> {
+    if hashes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut out: Vec<BlobRow> = Vec::new();
+    // SQLite defaults to 999 parameters; stay under that.
+    const CHUNK: usize = 900;
+
+    for chunk in hashes.chunks(CHUNK) {
+        let placeholders = std::iter::repeat("?")
+            .take(chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql =
+            format!("SELECT hash, content, mime_type FROM blobs WHERE hash IN ({placeholders})");
+        let params: Vec<Value> = chunk.iter().map(|h| Value::Text(h.clone())).collect();
+
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+            Ok(BlobRow {
+                hash: row.get(0)?,
+                content: row.get(1)?,
+                mime_type: row.get(2)?,
+            })
+        })?;
+        out.extend(rows.filter_map(|r| r.ok()));
+    }
+
+    Ok(out)
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,14 @@ pub enum HarliteError {
     /// URL parsing error for malformed URLs.
     #[error("URL parsing error: {0}")]
     UrlParse(#[from] url::ParseError),
+
+    /// Regex compilation error.
+    #[error("Regex error: {0}")]
+    Regex(#[from] regex::Error),
+
+    /// Timestamp parsing error.
+    #[error("Timestamp parsing error: {0}")]
+    TimeParse(#[from] chrono::ParseError),
 }
 
 /// Convenience result type for harlite operations.

--- a/src/har/parser.rs
+++ b/src/har/parser.rs
@@ -7,12 +7,12 @@ use std::path::Path;
 
 use crate::error::Result;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Har {
     pub log: Log,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Log {
     pub version: Option<String>,
     pub creator: Option<Creator>,
@@ -21,19 +21,19 @@ pub struct Log {
     pub entries: Vec<Entry>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Creator {
     pub name: String,
     pub version: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Browser {
     pub name: String,
     pub version: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page {
     pub started_date_time: String,
@@ -42,14 +42,14 @@ pub struct Page {
     pub page_timings: Option<PageTimings>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PageTimings {
     pub on_content_load: Option<f64>,
     pub on_load: Option<f64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Entry {
     pub pageref: Option<String>,
@@ -59,11 +59,12 @@ pub struct Entry {
     pub response: Response,
     pub cache: Option<serde_json::Value>,
     pub timings: Option<Timings>,
+    #[serde(rename = "serverIPAddress", alias = "serverIpAddress")]
     pub server_ip_address: Option<String>,
     pub connection: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Request {
     pub method: String,
@@ -77,7 +78,7 @@ pub struct Request {
     pub body_size: Option<i64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Response {
     pub status: i32,
@@ -86,12 +87,13 @@ pub struct Response {
     pub cookies: Option<Vec<Cookie>>,
     pub headers: Vec<Header>,
     pub content: Content,
+    #[serde(rename = "redirectURL", alias = "redirectUrl")]
     pub redirect_url: Option<String>,
     pub headers_size: Option<i64>,
     pub body_size: Option<i64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Content {
     pub size: i64,
@@ -101,7 +103,7 @@ pub struct Content {
     pub encoding: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Header {
     pub name: String,
     pub value: String,
@@ -119,13 +121,13 @@ pub struct Cookie {
     pub secure: Option<bool>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct QueryParam {
     pub name: String,
     pub value: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostData {
     pub mime_type: Option<String>,
@@ -133,7 +135,7 @@ pub struct PostData {
     pub params: Option<Vec<PostParam>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostParam {
     pub name: String,
@@ -142,7 +144,7 @@ pub struct PostParam {
     pub content_type: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Timings {
     pub blocked: Option<f64>,
     pub dns: Option<f64>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod db;
 mod error;
 mod har;
 
+use commands::{run_export, ExportOptions};
 use commands::{run_import, run_info, run_schema, ImportOptions};
 
 #[derive(Parser)]
@@ -58,6 +59,88 @@ enum Commands {
         /// Database file to inspect
         database: PathBuf,
     },
+
+    /// Export a SQLite database back to HAR format
+    Export {
+        /// Database file to export
+        database: PathBuf,
+
+        /// Output HAR file (default: <database>.har). Use '-' for stdout.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Include stored request/response bodies in the HAR (if present)
+        #[arg(long)]
+        bodies: bool,
+
+        /// Write compact JSON (disable pretty-printing)
+        #[arg(long)]
+        compact: bool,
+
+        /// Exact URL match (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        url: Vec<String>,
+
+        /// URL substring match (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        url_contains: Vec<String>,
+
+        /// URL regex match (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        url_regex: Vec<String>,
+
+        /// Hostname filter (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        host: Vec<String>,
+
+        /// HTTP method filter (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        method: Vec<String>,
+
+        /// HTTP status filter (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        status: Vec<i32>,
+
+        /// Response MIME type substring match (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        mime: Vec<String>,
+
+        /// URL extension filter (repeatable, comma-separated allowed; e.g. 'js,css,json')
+        #[arg(long, value_delimiter = ',', action = clap::ArgAction::Append)]
+        ext: Vec<String>,
+
+        /// Filter by import source filename (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        source: Vec<String>,
+
+        /// Filter by import source filename substring match (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        source_contains: Vec<String>,
+
+        /// Only export entries on/after this timestamp (RFC3339) or date (YYYY-MM-DD)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Only export entries on/before this timestamp (RFC3339) or date (YYYY-MM-DD)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Minimum request body size (e.g., '1KB', '500B')
+        #[arg(long)]
+        min_request_size: Option<String>,
+
+        /// Maximum request body size (e.g., '100KB', 'unlimited')
+        #[arg(long)]
+        max_request_size: Option<String>,
+
+        /// Minimum response body size (e.g., '1KB', '500B')
+        #[arg(long)]
+        min_response_size: Option<String>,
+
+        /// Maximum response body size (e.g., '100KB', 'unlimited')
+        #[arg(long)]
+        max_response_size: Option<String>,
+    },
 }
 
 fn parse_size(s: &str) -> Option<usize> {
@@ -104,6 +187,52 @@ fn main() {
         Commands::Schema { database } => run_schema(database),
 
         Commands::Info { database } => run_info(database),
+
+        Commands::Export {
+            database,
+            output,
+            bodies,
+            compact,
+            url,
+            url_contains,
+            url_regex,
+            host,
+            method,
+            status,
+            mime,
+            ext,
+            source,
+            source_contains,
+            from,
+            to,
+            min_request_size,
+            max_request_size,
+            min_response_size,
+            max_response_size,
+        } => {
+            let options = ExportOptions {
+                output,
+                pretty: !compact,
+                include_bodies: bodies,
+                url,
+                url_contains,
+                url_regex,
+                host,
+                method,
+                status,
+                mime_contains: mime,
+                ext,
+                source,
+                source_contains,
+                from,
+                to,
+                min_request_size,
+                max_request_size,
+                min_response_size,
+                max_response_size,
+            };
+            run_export(database, &options)
+        }
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
Implements harlite export to convert a harlite SQLite DB back to HAR 1.2.

- Filters: url/url-contains/url-regex, host, method, status, mime substring, ext, from/to, size ranges, source/source-contains
- Optional --bodies to include stored request/response bodies (base64 when needed)
- Preserves ordering by started_at

Closes #1.