### PR TITLE
Add harlite query command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,9 +1,11 @@
 mod export;
 mod import;
 mod info;
+mod query;
 mod schema;
 
 pub use export::{run_export, ExportOptions};
 pub use import::{run_import, ImportOptions};
 pub use info::run_info;
+pub use query::{run_query, OutputFormat, QueryOptions};
 pub use schema::run_schema;

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,10 @@ pub enum HarliteError {
     /// Timestamp parsing error.
     #[error("Timestamp parsing error: {0}")]
     TimeParse(#[from] chrono::ParseError),
+
+    /// Invalid command-line arguments or options.
+    #[error("{0}")]
+    InvalidArgs(String),
 }
 
 /// Convenience result type for harlite operations.


### PR DESCRIPTION
Closes #2

Adds a built-in `harlite query` subcommand to run read-only SQL against a harlite database and output results as table, csv, or json. Supports limit/offset wrapping and piping-friendly output.