### PR TITLE
Harden external blob reads, cap decompression, stream outputs

### DIFF
--- a/src/db/writer.rs
+++ b/src/db/writer.rs
@@ -325,6 +325,8 @@ fn maybe_index_response_body_fts(
     Ok(())
 }
 
+const DEFAULT_MAX_DECOMPRESSED_BYTES: usize = 50 * 1024 * 1024;
+
 /// Insert an entry into the database and optionally store bodies.
 pub fn insert_entry(
     conn: &Connection,
@@ -372,8 +374,10 @@ pub fn insert_entry(
             if type_ok && !body.is_empty() {
                 if options.decompress_bodies {
                     if let Some(enc) = header_value(&entry.response.headers, "content-encoding") {
+                        let decompress_limit =
+                            options.max_body_size.unwrap_or(DEFAULT_MAX_DECOMPRESSED_BYTES);
                         if let Some(decompressed) =
-                            decompress_body(&body, &enc, options.max_body_size)
+                            decompress_body(&body, &enc, Some(decompress_limit))
                         {
                             if options.keep_compressed {
                                 let raw_size_ok =

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,14 @@ enum Commands {
         #[arg(long)]
         bodies: bool,
 
+        /// Allow reading external blob paths from the database
+        #[arg(long)]
+        allow_external_paths: bool,
+
+        /// Root directory for external blob paths (defaults to database directory)
+        #[arg(long, value_name = "DIR")]
+        external_path_root: Option<PathBuf>,
+
         /// Write compact JSON (disable pretty-printing)
         #[arg(long)]
         compact: bool,
@@ -281,6 +289,14 @@ enum Commands {
         /// Maximum body size to index (e.g., '1MB', '100KB', 'unlimited')
         #[arg(long, default_value = "1MB")]
         max_body_size: String,
+
+        /// Allow reading external blob paths from the database
+        #[arg(long)]
+        allow_external_paths: bool,
+
+        /// Root directory for external blob paths (defaults to database directory)
+        #[arg(long, value_name = "DIR")]
+        external_path_root: Option<PathBuf>,
     },
 }
 
@@ -348,6 +364,8 @@ fn main() {
             database,
             output,
             bodies,
+            allow_external_paths,
+            external_path_root,
             compact,
             url,
             url_contains,
@@ -370,6 +388,8 @@ fn main() {
                 output,
                 pretty: !compact,
                 include_bodies: bodies,
+                allow_external_paths,
+                external_path_root,
                 url,
                 url_contains,
                 url_regex,
@@ -452,7 +472,15 @@ fn main() {
             database,
             tokenizer,
             max_body_size,
-        } => run_fts_rebuild(database, tokenizer, parse_size(&max_body_size)),
+            allow_external_paths,
+            external_path_root,
+        } => run_fts_rebuild(
+            database,
+            tokenizer,
+            parse_size(&max_body_size),
+            allow_external_paths,
+            external_path_root,
+        ),
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
## Summary
- gate external blob path reads behind explicit flags and root validation
- cap decompression output when max body size is unlimited
- stream query/search JSON and table output to avoid buffering

## Testing
- cargo test --test integration
