### PR TITLE
Add shell completions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ cargo build --release
 ```
 
 Performance note: HAR parsing streams entries from disk using `serde_json::Deserializer` to avoid loading the full JSON blob at once; memory still scales with the number of entries imported.
+
+### Shell completions
+
+Generate completions from the CLI (always in sync with flags/subcommands):
+
+```bash
+harlite completions bash > ~/.local/share/bash-completion/completions/harlite
+harlite completions zsh > ~/.zsh/completions/_harlite
+harlite completions fish > ~/.config/fish/completions/harlite.fish
+```
+
+For zsh, ensure your `~/.zsh/completions` directory is in `fpath` (e.g., add `fpath=(~/.zsh/completions $fpath)` to `~/.zshrc`).
+
+PowerShell (save and dot-source in your profile):
+
+```powershell
+harlite completions powershell > $HOME\Documents\PowerShell\Completions\harlite.ps1
+". $HOME\Documents\PowerShell\Completions\harlite.ps1" >> $PROFILE
+```
 ## Quick Start
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 use std::process;
 
@@ -351,6 +351,13 @@ enum Commands {
         #[arg(long, value_name = "DIR")]
         external_path_root: Option<PathBuf>,
     },
+
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
 }
 
 fn main() {
@@ -544,6 +551,12 @@ fn main() {
                 allow_external_paths,
                 external_path_root,
             )
+        }
+
+        Commands::Completions { shell } => {
+            let mut cmd = Cli::command();
+            clap_complete::generate(shell, &mut cmd, "harlite", &mut std::io::stdout());
+            Ok(())
         }
     }
     })();


### PR DESCRIPTION
Closes #62\n\n## Summary\n- add a clap-generated completions subcommand\n- document shell completion install steps\n\n## Testing\n- not run (not requested)