### PR TITLE
Fix query quiet flag and add unit coverage

### DIFF
--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::{HarliteError, Result};
 
@@ -8,8 +8,12 @@ pub fn resolve_database(database: Option<PathBuf>) -> Result<PathBuf> {
         return Ok(db);
     }
 
+    resolve_database_in_dir(Path::new("."))
+}
+
+fn resolve_database_in_dir(dir: &Path) -> Result<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
-    for entry in fs::read_dir(".")? {
+    for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         if !path.is_file() {
@@ -30,5 +34,49 @@ pub fn resolve_database(database: Option<PathBuf>) -> Result<PathBuf> {
             "No database specified and found {} .db files in the current directory; please pass a database path",
             n
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_database_in_dir;
+    use crate::error::HarliteError;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_database_in_dir_returns_single_match() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("only.db");
+        std::fs::write(&db_path, b"").unwrap();
+
+        let resolved = resolve_database_in_dir(tmp.path()).unwrap();
+        assert_eq!(resolved, db_path);
+    }
+
+    #[test]
+    fn resolve_database_in_dir_errors_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let err = resolve_database_in_dir(tmp.path()).unwrap_err();
+        match err {
+            HarliteError::InvalidArgs(msg) => {
+                assert!(msg.contains("no .db files"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_database_in_dir_errors_when_multiple() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("one.db"), b"").unwrap();
+        std::fs::write(tmp.path().join("two.db"), b"").unwrap();
+
+        let err = resolve_database_in_dir(tmp.path()).unwrap_err();
+        match err {
+            HarliteError::InvalidArgs(msg) => {
+                assert!(msg.contains("found 2 .db files"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,9 +520,12 @@ enum Commands {
         offset: Option<u64>,
 
         /// Suppress extra output (for piping)
-        #[arg(long, action = clap::ArgAction::SetTrue)]
-        #[arg(long = "no-quiet", action = clap::ArgAction::SetFalse)]
+        #[arg(long, action = clap::ArgAction::SetTrue, conflicts_with = "no_quiet")]
         quiet: Option<bool>,
+
+        /// Always show headers and row counts (overrides config quiet)
+        #[arg(long = "no-quiet", action = clap::ArgAction::SetTrue, conflicts_with = "quiet")]
+        no_quiet: bool,
     },
 
     /// Start an interactive SQL REPL
@@ -557,9 +560,12 @@ enum Commands {
         offset: Option<u64>,
 
         /// Suppress extra output (for piping)
-        #[arg(long, action = clap::ArgAction::SetTrue)]
-        #[arg(long = "no-quiet", action = clap::ArgAction::SetFalse)]
+        #[arg(long, action = clap::ArgAction::SetTrue, conflicts_with = "no_quiet")]
         quiet: Option<bool>,
+
+        /// Always show headers and row counts (overrides config quiet)
+        #[arg(long = "no-quiet", action = clap::ArgAction::SetTrue, conflicts_with = "quiet")]
+        no_quiet: bool,
     },
 
     /// Rebuild the response body FTS index for an existing database
@@ -916,8 +922,10 @@ fn main() {
                 limit,
                 offset,
                 quiet,
+                no_quiet,
             } => {
                 let defaults = &resolved.query;
+                let quiet = if no_quiet { Some(false) } else { quiet };
                 let options = QueryOptions {
                     format: format.unwrap_or(defaults.format),
                     limit: limit.or(defaults.limit),
@@ -934,8 +942,10 @@ fn main() {
                 limit,
                 offset,
                 quiet,
+                no_quiet,
             } => {
                 let defaults = &resolved.search;
+                let quiet = if no_quiet { Some(false) } else { quiet };
                 let options = QueryOptions {
                     format: format.unwrap_or(defaults.format),
                     limit: limit.or(defaults.limit),


### PR DESCRIPTION
Summary:
- Fix --quiet/--no-quiet behavior for query/search CLI flags
- Add unit tests for database resolution and SQL normalization/wrapping
- Improve SQL parser state handling for block comments

Testing:
- cargo test