### PR TITLE
PR 91 feedback fixes

### DIFF
--- a/src/commands/entry_filter.rs
+++ b/src/commands/entry_filter.rs
@@ -45,6 +45,11 @@ pub fn load_entries_with_filters(
 
     let mut query = EntryQuery::default();
     let import_ids = load_import_ids_by_source(conn, &options.source, &options.source_contains)?;
+    if !options.source.is_empty() || !options.source_contains.is_empty() {
+        if import_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+    }
     if !import_ids.is_empty() {
         query.import_ids = import_ids;
     }

--- a/src/commands/export_data.rs
+++ b/src/commands/export_data.rs
@@ -51,10 +51,21 @@ pub fn run_export_data(database: PathBuf, options: &ExportDataOptions) -> Result
         }
     };
 
-    let mut writer = open_output(&output_path)?;
+    if matches!(options.format, DataExportFormat::Parquet) && output_path == PathBuf::from("-") {
+        return Err(HarliteError::InvalidArgs(
+            "Parquet export requires a file path; '-' is not supported".to_string(),
+        ));
+    }
+
     match options.format {
-        DataExportFormat::Csv => write_csv(&mut writer, &entries)?,
-        DataExportFormat::Jsonl => write_jsonl(&mut writer, &entries)?,
+        DataExportFormat::Csv => {
+            let mut writer = open_output(&output_path)?;
+            write_csv(&mut writer, &entries)?;
+        }
+        DataExportFormat::Jsonl => {
+            let mut writer = open_output(&output_path)?;
+            write_jsonl(&mut writer, &entries)?;
+        }
         DataExportFormat::Parquet => write_parquet(&output_path, &entries)?,
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -231,6 +231,29 @@ fn test_export_data_jsonl() {
 }
 
 #[test]
+fn test_export_data_source_filter_no_match() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let out_path = tmp.path().join("entries.jsonl");
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    harlite()
+        .args(["export-data", "--format", "jsonl", "--source", "missing.har", "-o"])
+        .arg(&out_path)
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let contents = fs::read_to_string(&out_path).unwrap_or_default();
+    assert!(contents.trim().is_empty());
+}
+
+#[test]
 fn test_openapi_basic() {
     let tmp = TempDir::new().unwrap();
     let db_path = tmp.path().join("test.db");


### PR DESCRIPTION
Addresses unaddressed review feedback from PR 91. Prioritized owner comments; ignored items the owner said to skip.

Summary:
- short-circuit export filters when source filters match no imports
- reject parquet export to stdout and avoid creating a literal "-" file
- add integration coverage for source filter no-match

Testing:
- cargo test -q