### PR TITLE
PR 95 feedback fixes

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -114,6 +114,7 @@ CREATE TABLE IF NOT EXISTS graphql_fields (
     entry_id INTEGER REFERENCES entries(id),
     field TEXT NOT NULL
 );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graphql_fields_entry_field ON graphql_fields(entry_id, field);
 CREATE INDEX IF NOT EXISTS idx_graphql_fields_field ON graphql_fields(field);
 CREATE INDEX IF NOT EXISTS idx_graphql_fields_entry ON graphql_fields(entry_id);
 

--- a/src/commands/otel.rs
+++ b/src/commands/otel.rs
@@ -997,6 +997,9 @@ mod tests {
             content_extensions: None,
             timings_extensions: None,
             post_data_extensions: None,
+            graphql_operation_type: None,
+            graphql_operation_name: None,
+            graphql_top_level_fields: None,
         }
     }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -119,6 +119,7 @@ CREATE TABLE IF NOT EXISTS graphql_fields (
     entry_id INTEGER REFERENCES entries(id),
     field TEXT NOT NULL
 );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graphql_fields_entry_field ON graphql_fields(entry_id, field);
 CREATE INDEX IF NOT EXISTS idx_graphql_fields_field ON graphql_fields(field);
 CREATE INDEX IF NOT EXISTS idx_graphql_fields_entry ON graphql_fields(entry_id);
 "#;
@@ -246,6 +247,7 @@ CREATE TABLE IF NOT EXISTS graphql_fields (
     entry_id INTEGER REFERENCES entries(id),
     field TEXT NOT NULL
 );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graphql_fields_entry_field ON graphql_fields(entry_id, field);
 CREATE INDEX IF NOT EXISTS idx_graphql_fields_field ON graphql_fields(field);
 CREATE INDEX IF NOT EXISTS idx_graphql_fields_entry ON graphql_fields(entry_id);
 
@@ -429,6 +431,7 @@ pub fn ensure_schema_upgrades(conn: &Connection) -> Result<()> {
 
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS graphql_fields (entry_id INTEGER REFERENCES entries(id), field TEXT NOT NULL);
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_graphql_fields_entry_field ON graphql_fields(entry_id, field);
          CREATE INDEX IF NOT EXISTS idx_graphql_fields_field ON graphql_fields(field);
          CREATE INDEX IF NOT EXISTS idx_graphql_fields_entry ON graphql_fields(entry_id);",
     )?;


### PR DESCRIPTION
Addresses unaddressed review feedback from PR 95.

Summary:
- merge GraphQL metadata into deduped entries during db merge
- add unique index for graphql_fields and de-duplicate inserted fields

Testing:
- cargo test -q