### PR TITLE
Fix #119: add direct HAR export filtering

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,14 +2,14 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::commands;
-use crate::commands::{
-    DataExportFormat, DedupStrategy, NameMatchMode, OutputFormat, WaterfallFormat,
-    WaterfallGroupBy,
-};
-#[cfg(feature = "otel")]
-use crate::commands::OtelExportFormat;
 #[cfg(feature = "serve")]
 use crate::commands::MatchMode;
+#[cfg(feature = "otel")]
+use crate::commands::OtelExportFormat;
+use crate::commands::{
+    DataExportFormat, DedupStrategy, ExportInputFormat, NameMatchMode, OutputFormat,
+    WaterfallFormat, WaterfallGroupBy,
+};
 use crate::db::ExtractBodiesKind;
 
 #[derive(Parser)]
@@ -369,10 +369,15 @@ pub enum Commands {
         top: Option<usize>,
     },
 
-    /// Export a SQLite database back to HAR format
+    /// Export a HAR or harlite DB back to a HAR file
     Export {
-        /// Database file to export
+        /// Database or HAR file to export
         database: PathBuf,
+
+        /// Input format override (`har` or `db`)
+        /// (takes precedence over extension-based inference)
+        #[arg(long, value_enum)]
+        format: Option<ExportInputFormat>,
 
         /// Output HAR file (default: <database>.har). Use '-' for stdout.
         #[arg(short, long)]

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -788,17 +788,16 @@ fn matches_har_filters(
             return false;
         }
     }
-    let Some(started_at) = parse_started_at(&entry.started_date_time) else {
-        return from.is_none() && to.is_none();
-    };
-    if let Some(from) = from {
-        if started_at < from {
-            return false;
+    if let Some(started_at) = parse_started_at(&entry.started_date_time) {
+        if let Some(from) = from {
+            if started_at < from {
+                return false;
+            }
         }
-    }
-    if let Some(to) = to {
-        if started_at > to {
-            return false;
+        if let Some(to) = to {
+            if started_at > to {
+                return false;
+            }
         }
     }
 
@@ -834,9 +833,12 @@ fn matches_har_source_filter(path: &str, source: &[String], source_contains: &[S
         return true;
     }
     if !source.is_empty() {
+        let path_filename = std::path::Path::new(path)
+            .file_name()
+            .and_then(|value| value.to_str());
         let has_exact_match = source
             .iter()
-            .any(|value| value == path || path.ends_with(value));
+            .any(|value| value == path || path_filename == Some(value.as_str()));
         if !has_exact_match {
             return false;
         }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -802,6 +802,7 @@ fn matches_har_filters(
     }
 
     let request_size = entry.request.body_size.unwrap_or(0);
+    let request_size = if request_size < 0 { 0 } else { request_size };
     if let Some(min) = min_request_size {
         if request_size < min {
             return false;

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -242,7 +242,7 @@ fn default_export_output_path(database: &Path, format: ExportInputFormat) -> Pat
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("export");
-            database.with_file_name(format!("{stem}.har"))
+            PathBuf::from(format!("{stem}.har"))
         }
         ExportInputFormat::Har => {
             let file_name = database
@@ -737,13 +737,14 @@ fn matches_har_filters(
     min_response_size: Option<i64>,
     max_response_size: Option<i64>,
 ) -> bool {
+    let entry_url = entry.request.url.to_ascii_lowercase();
     if !url.is_empty() && !url.iter().any(|value| value == &entry.request.url) {
         return false;
     }
     if !url_contains.is_empty()
         && !url_contains
             .iter()
-            .any(|value| entry.request.url.contains(value))
+            .any(|value| entry_url.contains(&value.to_ascii_lowercase()))
     {
         return false;
     }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{self, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use clap::ValueEnum;
 use regex::Regex;
 use rusqlite::Connection;
@@ -223,18 +223,40 @@ fn open_output(path: &Path) -> Result<Box<dyn Write>> {
 
 /// Export a harlite database or HAR back to a HAR file.
 pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
-    let output_path = options.output.clone().unwrap_or_else(|| {
-        let stem = database
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("export");
-        PathBuf::from(format!("{stem}.har"))
-    });
-
     let input_format = resolve_export_format(&database, options.format)?;
+    let output_path = options
+        .output
+        .clone()
+        .unwrap_or_else(|| default_export_output_path(&database, input_format));
+
     match input_format {
         ExportInputFormat::Db => run_export_from_db(&database, &output_path, options),
         ExportInputFormat::Har => run_export_from_har(&database, &output_path, options),
+    }
+}
+
+fn default_export_output_path(database: &Path, format: ExportInputFormat) -> PathBuf {
+    match format {
+        ExportInputFormat::Db => {
+            let stem = database
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("export");
+            database.with_file_name(format!("{stem}.har"))
+        }
+        ExportInputFormat::Har => {
+            let file_name = database
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("export");
+            let base = file_name
+                .trim_end_matches(".har.br")
+                .trim_end_matches(".har.gz")
+                .trim_end_matches(".har")
+                .trim_end_matches(".json");
+            let default = format!("{base}.filtered.har");
+            database.with_file_name(default)
+        }
     }
 }
 
@@ -655,8 +677,8 @@ fn run_export_from_har(database: &Path, output_path: &Path, options: &ExportOpti
             &options.status,
             &options.mime_contains,
             &ext_filters,
-            from.as_deref(),
-            to.as_deref(),
+            from,
+            to,
             min_request_size,
             max_request_size,
             min_response_size,
@@ -708,8 +730,8 @@ fn matches_har_filters(
     status: &[i32],
     mime_contains: &[String],
     exts: &HashSet<String>,
-    from: Option<&str>,
-    to: Option<&str>,
+    from: Option<DateTime<Utc>>,
+    to: Option<DateTime<Utc>>,
     min_request_size: Option<i64>,
     max_request_size: Option<i64>,
     min_response_size: Option<i64>,
@@ -765,13 +787,16 @@ fn matches_har_filters(
             return false;
         }
     }
+    let Some(started_at) = parse_started_at(&entry.started_date_time) else {
+        return from.is_none() && to.is_none();
+    };
     if let Some(from) = from {
-        if entry.started_date_time.as_str() < from {
+        if started_at < from {
             return false;
         }
     }
     if let Some(to) = to {
-        if entry.started_date_time.as_str() > to {
+        if started_at > to {
             return false;
         }
     }
@@ -880,7 +905,7 @@ fn write_exported_har(
     Ok(())
 }
 
-fn parse_started_at_bound(value: &str, is_end: bool) -> Result<String> {
+fn parse_started_at_bound(value: &str, is_end: bool) -> Result<DateTime<Utc>> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err(HarliteError::InvalidHar(
@@ -889,9 +914,7 @@ fn parse_started_at_bound(value: &str, is_end: bool) -> Result<String> {
     }
 
     if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(trimmed) {
-        return Ok(parsed
-            .with_timezone(&chrono::Utc)
-            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+        return Ok(parsed.with_timezone(&Utc));
     }
     let date = chrono::NaiveDate::parse_from_str(trimmed, "%Y-%m-%d")?;
     let dt = if is_end {
@@ -903,7 +926,13 @@ fn parse_started_at_bound(value: &str, is_end: bool) -> Result<String> {
             .and_then(|d| d.and_local_timezone(chrono::Utc).single())
             .ok_or_else(|| HarliteError::InvalidHar("Invalid start date".to_string()))?
     };
-    Ok(dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+    Ok(dt)
+}
+
+fn parse_started_at(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
 }
 
 fn resolve_export_format(

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,12 +1,15 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{self, BufWriter, Write};
+use std::io::{self, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
+use clap::ValueEnum;
+use regex::Regex;
 use rusqlite::Connection;
 use url::Url;
 
+use super::entry_filter::{load_entries_with_filters, EntryFilterOptions};
 use crate::db::{ensure_schema_upgrades, load_blobs_by_hashes, load_pages_for_imports, BlobRow};
 use crate::error::{HarliteError, Result};
 use crate::har::{
@@ -14,11 +17,19 @@ use crate::har::{
     QueryParam, Request, Response, Timings,
 };
 use crate::plugins::{PluginContext, PluginSet};
-use super::entry_filter::{load_entries_with_filters, EntryFilterOptions};
+
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+#[clap(rename_all = "lowercase")]
+pub enum ExportInputFormat {
+    Db,
+    Har,
+}
 
 /// Options for exporting a harlite database back to a HAR file.
 pub struct ExportOptions {
     pub output: Option<PathBuf>,
+    pub format: Option<ExportInputFormat>,
     pub pretty: bool,
     pub include_bodies: bool,
     pub include_raw_response_bodies: bool,
@@ -51,6 +62,7 @@ impl Default for ExportOptions {
     fn default() -> Self {
         Self {
             output: None,
+            format: None,
             pretty: true,
             include_bodies: false,
             include_raw_response_bodies: false,
@@ -209,9 +221,25 @@ fn open_output(path: &Path) -> Result<Box<dyn Write>> {
     Ok(Box::new(BufWriter::new(File::create(path)?)))
 }
 
-/// Export a harlite SQLite database back to a HAR file.
+/// Export a harlite database or HAR back to a HAR file.
 pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
-    let conn = Connection::open(&database)?;
+    let output_path = options.output.clone().unwrap_or_else(|| {
+        let stem = database
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("export");
+        PathBuf::from(format!("{stem}.har"))
+    });
+
+    let input_format = resolve_export_format(&database, options.format)?;
+    match input_format {
+        ExportInputFormat::Db => run_export_from_db(&database, &output_path, options),
+        ExportInputFormat::Har => run_export_from_har(&database, &output_path, options),
+    }
+}
+
+fn run_export_from_db(database: &Path, output_path: &Path, options: &ExportOptions) -> Result<()> {
+    let conn = Connection::open(database)?;
     ensure_schema_upgrades(&conn)?;
     let external_root = if options.allow_external_paths {
         let root = options
@@ -228,19 +256,9 @@ pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
         None
     };
 
-    let output_path = match &options.output {
-        Some(p) => p.clone(),
-        None => {
-            let stem = database
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("export");
-            PathBuf::from(format!("{stem}.har"))
-        }
-    };
     let output_str = output_path.to_string_lossy();
     let database_str = database.to_string_lossy();
-    let context = PluginContext {
+    let mut context = PluginContext {
         command: "export",
         source: None,
         database: Some(database_str.as_ref()),
@@ -433,7 +451,9 @@ pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
             || row.send_ms.is_some()
             || row.wait_ms.is_some()
             || row.receive_ms.is_some();
-        let wait_ms = normalize_ms(row.wait_ms).unwrap_or_else(|| if has_timing_parts { 0.0 } else { time_ms });
+        let wait_ms =
+            normalize_ms(row.wait_ms)
+                .unwrap_or_else(|| if has_timing_parts { 0.0 } else { time_ms });
         let timings = Some(Timings {
             blocked: normalize_ms(row.blocked_ms),
             dns: normalize_ms(row.dns_ms),
@@ -520,21 +540,12 @@ pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
         }
     }
 
-    let log_extensions = if !multi_import && import_ids.len() == 1 {
-        conn.query_row(
-            "SELECT log_extensions FROM imports WHERE id = ?1",
-            [import_ids[0]],
-            |row| row.get::<_, Option<String>>(0),
-        )
-        .ok()
-        .flatten()
-        .map(|s| extensions_from_json(Some(s.as_str())))
-        .unwrap_or_default()
-    } else {
-        Extensions::new()
+    let log_extensions = match (multi_import, import_ids.len()) {
+        (false, 1) => query_db_log_extension(&conn, import_ids[0])?,
+        _ => Extensions::new(),
     };
 
-    let har = Har {
+    let mut har = Har {
         log: Log {
             version: Some("1.2".to_string()),
             creator: Some(Creator {
@@ -552,7 +563,297 @@ pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
         },
     };
 
-    let export_outcome = options.plugins.run_exporters(&har, &context)?;
+    write_exported_har(
+        &mut har,
+        output_path,
+        options.pretty,
+        &options.plugins,
+        &mut context,
+    )
+}
+
+fn run_export_from_har(database: &Path, output_path: &Path, options: &ExportOptions) -> Result<()> {
+    let mut har = crate::har::parse_har_file(database)?;
+    let output_str = output_path.to_string_lossy();
+    let source = database.to_string_lossy();
+    let mut context = PluginContext {
+        command: "export",
+        source: Some(source.as_ref()),
+        database: None,
+        output: Some(output_str.as_ref()),
+    };
+
+    let from = options
+        .from
+        .as_deref()
+        .map(|value| parse_started_at_bound(value, false))
+        .transpose()?;
+    let to = options
+        .to
+        .as_deref()
+        .map(|value| parse_started_at_bound(value, true))
+        .transpose()?;
+    let min_request_size = options
+        .min_request_size
+        .as_deref()
+        .map(crate::size::parse_size_bytes_i64)
+        .transpose()?
+        .flatten();
+    let max_request_size = options
+        .max_request_size
+        .as_deref()
+        .map(crate::size::parse_size_bytes_i64)
+        .transpose()?
+        .flatten();
+    let min_response_size = options
+        .min_response_size
+        .as_deref()
+        .map(crate::size::parse_size_bytes_i64)
+        .transpose()?
+        .flatten();
+    let max_response_size = options
+        .max_response_size
+        .as_deref()
+        .map(crate::size::parse_size_bytes_i64)
+        .transpose()?
+        .flatten();
+    let url_regexes: Vec<Regex> = options
+        .url_regex
+        .iter()
+        .map(|s| Regex::new(s))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let ext_filters: HashSet<String> = options
+        .ext
+        .iter()
+        .map(|value| value.trim().trim_start_matches('.').to_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect();
+    let mut needed_pages: HashSet<String> = HashSet::new();
+
+    let mut filtered_entries: Vec<Entry> = Vec::with_capacity(har.log.entries.len());
+    let source_path = database.to_string_lossy().to_string();
+    if !matches_har_source_filter(&source_path, &options.source, &options.source_contains) {
+        har.log.entries.clear();
+        har.log.pages = None;
+        return write_exported_har(
+            &mut har,
+            output_path,
+            options.pretty,
+            &options.plugins,
+            &mut context,
+        );
+    }
+
+    for entry in har.log.entries.drain(..) {
+        if !matches_har_filters(
+            &entry,
+            &options.url,
+            &options.url_contains,
+            &url_regexes,
+            &options.host,
+            &options.method,
+            &options.status,
+            &options.mime_contains,
+            &ext_filters,
+            from.as_deref(),
+            to.as_deref(),
+            min_request_size,
+            max_request_size,
+            min_response_size,
+            max_response_size,
+        ) {
+            continue;
+        }
+
+        let entry = apply_har_body_inclusion(entry, options.include_bodies);
+        if let Some(page_id) = entry.pageref.clone() {
+            needed_pages.insert(page_id);
+        }
+        if let Some(entry) = options.plugins.apply_export_entry(entry, &context)? {
+            filtered_entries.push(entry);
+        }
+    }
+
+    let filtered_pages = har
+        .log
+        .pages
+        .take()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|page| needed_pages.contains(&page.id))
+        .collect::<Vec<_>>();
+    har.log.entries = filtered_entries;
+    har.log.pages = if filtered_pages.is_empty() {
+        None
+    } else {
+        Some(filtered_pages)
+    };
+
+    write_exported_har(
+        &mut har,
+        output_path,
+        options.pretty,
+        &options.plugins,
+        &mut context,
+    )
+}
+
+fn matches_har_filters(
+    entry: &Entry,
+    url: &[String],
+    url_contains: &[String],
+    url_regexes: &[Regex],
+    host: &[String],
+    method: &[String],
+    status: &[i32],
+    mime_contains: &[String],
+    exts: &HashSet<String>,
+    from: Option<&str>,
+    to: Option<&str>,
+    min_request_size: Option<i64>,
+    max_request_size: Option<i64>,
+    min_response_size: Option<i64>,
+    max_response_size: Option<i64>,
+) -> bool {
+    if !url.is_empty() && !url.iter().any(|value| value == &entry.request.url) {
+        return false;
+    }
+    if !url_contains.is_empty()
+        && !url_contains
+            .iter()
+            .any(|value| entry.request.url.contains(value))
+    {
+        return false;
+    }
+    if !url_regexes.is_empty() && !url_regexes.iter().any(|re| re.is_match(&entry.request.url)) {
+        return false;
+    }
+    if !host.is_empty() {
+        let entry_host = Url::parse(&entry.request.url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_owned));
+        if entry_host.is_none()
+            || !host
+                .iter()
+                .any(|h| entry_host.as_deref() == Some(h.as_str()))
+        {
+            return false;
+        }
+    }
+    if !method.is_empty() && !method.iter().any(|value| value == &entry.request.method) {
+        return false;
+    }
+    if !status.is_empty() && !status.iter().any(|value| value == &entry.response.status) {
+        return false;
+    }
+    if !mime_contains.is_empty() {
+        let response_mime = entry.response.content.mime_type.as_deref().unwrap_or("");
+        if !mime_contains.iter().any(|value| {
+            response_mime
+                .to_ascii_lowercase()
+                .contains(&value.to_ascii_lowercase())
+        }) {
+            return false;
+        }
+    }
+    if !exts.is_empty() {
+        if let Some(ext) = entry_url_extension(&entry.request.url) {
+            if !exts.contains(&ext) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    if let Some(from) = from {
+        if entry.started_date_time.as_str() < from {
+            return false;
+        }
+    }
+    if let Some(to) = to {
+        if entry.started_date_time.as_str() > to {
+            return false;
+        }
+    }
+
+    let request_size = entry.request.body_size.unwrap_or(0);
+    if let Some(min) = min_request_size {
+        if request_size < min {
+            return false;
+        }
+    }
+    if let Some(max) = max_request_size {
+        if request_size > max {
+            return false;
+        }
+    }
+    let response_size = entry.response.content.size;
+    if let Some(min) = min_response_size {
+        if response_size < min {
+            return false;
+        }
+    }
+    if let Some(max) = max_response_size {
+        if response_size > max {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn matches_har_source_filter(path: &str, source: &[String], source_contains: &[String]) -> bool {
+    if source.is_empty() && source_contains.is_empty() {
+        return true;
+    }
+    if !source.is_empty() {
+        let has_exact_match = source
+            .iter()
+            .any(|value| value == path || path.ends_with(value));
+        if !has_exact_match {
+            return false;
+        }
+    }
+    if !source_contains.is_empty() {
+        let has_contains = source_contains.iter().any(|value| path.contains(value));
+        if !has_contains {
+            return false;
+        }
+    }
+    true
+}
+
+fn apply_har_body_inclusion(mut entry: Entry, include_bodies: bool) -> Entry {
+    if include_bodies {
+        return entry;
+    }
+
+    if let Some(post_data) = entry.request.post_data.as_mut() {
+        post_data.text = None;
+    }
+    entry.response.content.text = None;
+    entry.response.content.encoding = None;
+    entry
+}
+
+fn entry_url_extension(url: &str) -> Option<String> {
+    let parsed = Url::parse(url).ok()?;
+    let file = parsed.path().rsplit('/').next().unwrap_or("");
+    let ext = file.rsplit('.').next()?;
+    if ext == file {
+        return None;
+    }
+    Some(ext.to_lowercase())
+}
+
+fn write_exported_har(
+    har: &mut Har,
+    output_path: &Path,
+    pretty: bool,
+    plugins: &PluginSet,
+    context: &mut PluginContext<'_>,
+) -> Result<()> {
+    let export_outcome = plugins.run_exporters(har, context)?;
     if export_outcome.skip_default {
         if export_outcome.ran {
             println!("Export handled by plugin(s); skipping default HAR output.");
@@ -560,15 +861,15 @@ pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
         return Ok(());
     }
 
-    let mut writer = open_output(&output_path)?;
-    if options.pretty {
+    let mut writer = open_output(output_path)?;
+    if pretty {
         serde_json::to_writer_pretty(&mut writer, &har)?;
     } else {
         serde_json::to_writer(&mut writer, &har)?;
     }
     writer.write_all(b"\n")?;
 
-    if output_path != PathBuf::from("-") {
+    if output_path != Path::new("-") {
         println!(
             "Exported {} entries to {}",
             har.log.entries.len(),
@@ -577,4 +878,109 @@ pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn parse_started_at_bound(value: &str, is_end: bool) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(HarliteError::InvalidHar(
+            "Empty timestamp bound".to_string(),
+        ));
+    }
+
+    if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(trimmed) {
+        return Ok(parsed
+            .with_timezone(&chrono::Utc)
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+    }
+    let date = chrono::NaiveDate::parse_from_str(trimmed, "%Y-%m-%d")?;
+    let dt = if is_end {
+        date.and_hms_milli_opt(23, 59, 59, 999)
+            .and_then(|d| d.and_local_timezone(chrono::Utc).single())
+            .ok_or_else(|| HarliteError::InvalidHar("Invalid end date".to_string()))?
+    } else {
+        date.and_hms_opt(0, 0, 0)
+            .and_then(|d| d.and_local_timezone(chrono::Utc).single())
+            .ok_or_else(|| HarliteError::InvalidHar("Invalid start date".to_string()))?
+    };
+    Ok(dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+}
+
+fn resolve_export_format(
+    path: &Path,
+    format: Option<ExportInputFormat>,
+) -> Result<ExportInputFormat> {
+    match format {
+        Some(format) => Ok(format),
+        None => detect_export_format(path),
+    }
+}
+
+fn detect_export_format(path: &Path) -> Result<ExportInputFormat> {
+    if is_db_path(path) {
+        return Ok(ExportInputFormat::Db);
+    }
+    if is_har_path(path) {
+        return Ok(ExportInputFormat::Har);
+    }
+    Err(HarliteError::InvalidArgs(format!(
+        "Could not infer export input format for {}. Use --format to specify har|db",
+        path.display()
+    )))
+}
+
+fn is_db_path(path: &Path) -> bool {
+    let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
+        return is_sqlite_file(path);
+    };
+
+    let ext = ext.to_ascii_lowercase();
+    if matches!(ext.as_str(), "db" | "db3" | "sqlite" | "sqlite3") {
+        return true;
+    }
+
+    is_sqlite_file(path)
+}
+
+fn is_sqlite_file(path: &Path) -> bool {
+    let Ok(mut file) = File::open(path) else {
+        return false;
+    };
+
+    let mut header = [0u8; 16];
+    let Ok(read_len) = file.read(&mut header) else {
+        return false;
+    };
+    if read_len < 16 {
+        return false;
+    }
+
+    header == *b"SQLite format 3\0"
+}
+
+fn is_har_path(path: &Path) -> bool {
+    let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    let ext = ext.to_ascii_lowercase();
+    if matches!(ext.as_str(), "har" | "json") {
+        return true;
+    }
+    if ext == "br" || ext == "gz" {
+        let name = path.to_string_lossy().to_ascii_lowercase();
+        return name.ends_with(".har.br") || name.ends_with(".har.gz");
+    }
+    false
+}
+
+fn query_db_log_extension(conn: &Connection, import_id: i64) -> Result<Extensions> {
+    match conn.query_row(
+        "SELECT log_extensions FROM imports WHERE id = ?1",
+        [import_id],
+        |row| row.get::<_, Option<String>>(0),
+    ) {
+        Ok(Some(s)) => Ok(extensions_from_json(Some(s.as_str()))),
+        Ok(None) => Ok(Extensions::new()),
+        Err(_) => Ok(Extensions::new()),
+    }
 }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -814,6 +814,7 @@ fn matches_har_filters(
         }
     }
     let response_size = entry.response.content.size;
+    let response_size = if response_size < 0 { 0 } else { response_size };
     if let Some(min) = min_response_size {
         if response_size < min {
             return false;
@@ -856,6 +857,7 @@ fn apply_har_body_inclusion(mut entry: Entry, include_bodies: bool) -> Entry {
 
     if let Some(post_data) = entry.request.post_data.as_mut() {
         post_data.text = None;
+        post_data.params = None;
     }
     entry.response.content.text = None;
     entry.response.content.encoding = None;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,7 +33,7 @@ mod waterfall;
 pub use diff::{run_diff, DiffOptions};
 pub use analyze::{run_analyze, AnalyzeOptions};
 pub use entry_filter::EntryFilterOptions;
-pub use export::{run_export, ExportOptions};
+pub use export::{run_export, ExportInputFormat, ExportOptions};
 pub use export_data::{run_export_data, DataExportFormat, ExportDataOptions};
 pub use fts::{run_fts_rebuild, FtsTokenizer};
 pub use import::{run_import, ImportOptions};

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::commands::{DedupStrategy, FtsTokenizer, NameMatchMode, OutputFormat};
+use crate::commands::{
+    DedupStrategy, ExportInputFormat, FtsTokenizer, NameMatchMode, OutputFormat,
+};
 use crate::db::ExtractBodiesKind;
 use crate::error::{HarliteError, Result};
 use crate::plugins::PluginConfig;
@@ -102,6 +104,7 @@ pub struct ReplayConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct ExportConfig {
     pub output: Option<PathBuf>,
+    pub format: Option<ExportInputFormat>,
     pub bodies: Option<bool>,
     pub bodies_raw: Option<bool>,
     pub allow_external_paths: Option<bool>,
@@ -289,6 +292,7 @@ pub struct ResolvedReplayConfig {
 #[derive(Clone, Debug, Serialize)]
 pub struct ResolvedExportConfig {
     pub output: Option<PathBuf>,
+    pub format: Option<ExportInputFormat>,
     pub bodies: bool,
     pub bodies_raw: bool,
     pub allow_external_paths: bool,
@@ -487,6 +491,7 @@ impl Default for ResolvedExportConfig {
     fn default() -> Self {
         Self {
             output: None,
+            format: None,
             bodies: false,
             bodies_raw: false,
             allow_external_paths: false,
@@ -818,6 +823,9 @@ impl ResolvedReplayConfig {
 
 impl ResolvedExportConfig {
     fn apply(&mut self, cfg: &ExportConfig) {
+        if let Some(value) = cfg.format {
+            self.format = Some(value);
+        }
         if let Some(value) = cfg.output.clone() {
             self.output = Some(value);
         }
@@ -1169,6 +1177,7 @@ impl CdpConfig {
 
 impl ExportConfig {
     fn merge(&mut self, other: ExportConfig) {
+        merge_opt(&mut self.format, other.format);
         merge_opt(&mut self.output, other.output);
         merge_opt(&mut self.bodies, other.bodies);
         merge_opt(&mut self.bodies_raw, other.bodies_raw);

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,11 +4,11 @@ use clap::CommandFactory;
 use crate::cli::{Cli, Commands};
 use crate::commands::{
     run_analyze, run_diff, run_export, run_export_data, run_fts_rebuild, run_import, run_imports,
-    run_info, run_merge, run_openapi, run_pii, run_prune, run_query, run_redact, run_schema,
-    run_report, run_search, run_stats, run_waterfall, AnalyzeOptions, DiffOptions, EntryFilterOptions,
-    ExportDataOptions, ExportOptions, ImportOptions, InfoOptions, MergeOptions, OpenApiOptions,
-    PiiOptions, QueryOptions, RedactOptions, ReportOptions, StatsOptions, WaterfallFormat,
-    WaterfallGroupBy, WaterfallOptions,
+    run_info, run_merge, run_openapi, run_pii, run_prune, run_query, run_redact, run_report,
+    run_schema, run_search, run_stats, run_waterfall, AnalyzeOptions, DiffOptions,
+    EntryFilterOptions, ExportDataOptions, ExportOptions, ImportOptions, InfoOptions, MergeOptions,
+    OpenApiOptions, PiiOptions, QueryOptions, RedactOptions, ReportOptions, StatsOptions,
+    WaterfallFormat, WaterfallGroupBy, WaterfallOptions,
 };
 #[cfg(feature = "cdp")]
 use crate::commands::{run_cdp, CdpOptions};
@@ -283,6 +283,7 @@ pub fn run(cli: Cli) -> Result<()> {
 
         Commands::Export {
             database,
+            format,
             output,
             bodies,
             bodies_raw,
@@ -325,6 +326,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 allow_external_paths: allow_external_paths.unwrap_or(defaults.allow_external_paths),
                 external_path_root: external_path_root
                     .or_else(|| defaults.external_path_root.clone()),
+                format: format.or(defaults.format),
                 url: url.unwrap_or_else(|| defaults.url.clone()),
                 url_contains: url_contains.unwrap_or_else(|| defaults.url_contains.clone()),
                 url_regex: url_regex.unwrap_or_else(|| defaults.url_regex.clone()),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1915,6 +1915,76 @@ fn test_export_har_unknown_response_size_treated_as_zero_for_filtering() {
 }
 
 #[test]
+fn test_export_har_invalid_request_size_still_applies_size_filters() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("invalid-request-size.har");
+    let output = tmp.path().join("invalid-request-size.filtered.har");
+    let har = r#"{
+      "log": {
+        "version": "1.2",
+        "creator": {"name": "test", "version": "1.0"},
+        "entries": [
+          {
+            "startedDateTime": "2024-01-15T10:30:00.000Z",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/unknown",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": -1
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 5,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          }
+        ]
+      }
+    }"#;
+
+    fs::write(&input, har).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--method",
+            "GET",
+            "--min-request-size",
+            "0",
+        ])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 1 entries"));
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&output).unwrap()).unwrap();
+    let entries = exported["log"]["entries"]
+        .as_array()
+        .expect("entries array should exist");
+    assert_eq!(entries.len(), 1);
+}
+
+#[test]
 fn test_export_har_source_matches_only_exact_path_or_basename() {
     let tmp = TempDir::new().unwrap();
     let input = tmp.path().join("keep.har");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1915,6 +1915,146 @@ fn test_export_har_unknown_response_size_treated_as_zero_for_filtering() {
 }
 
 #[test]
+fn test_export_har_source_matches_only_exact_path_or_basename() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("keep.har");
+    let output = tmp.path().join("keep.filtered.har");
+
+    fs::copy("tests/fixtures/simple.har", &input).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--source",
+            "keep.har",
+            "--method",
+            "GET",
+        ])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 1 entries"));
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&output).unwrap()).unwrap();
+    let entries = exported["log"]["entries"]
+        .as_array()
+        .expect("entries array should exist");
+    assert_eq!(entries.len(), 1);
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--source",
+            "eep.har",
+            "--method",
+            "GET",
+        ])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 0 entries"));
+}
+
+#[test]
+fn test_export_har_invalid_started_date_still_applies_size_filters() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("invalid-date.har");
+    let output = tmp.path().join("invalid-date.filtered.har");
+    let har = r#"{
+      "log": {
+        "version": "1.2",
+        "creator": {"name": "test", "version": "1.0"},
+        "entries": [
+          {
+            "startedDateTime": "not-a-date",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/invalid",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 5,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          },
+          {
+            "startedDateTime": "2024-01-15T10:30:01.000Z",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/valid",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 25,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          }
+        ]
+      }
+    }"#;
+
+    fs::write(&input, har).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--method",
+            "GET",
+            "--min-response-size",
+            "10",
+        ])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 1 entries"));
+}
+
+#[test]
 fn test_export_with_format_override_on_extensionless_input() {
     let tmp = TempDir::new().unwrap();
     let input = tmp.path().join("session");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1575,6 +1575,30 @@ fn test_export_direct_har_filter() {
 }
 
 #[test]
+fn test_export_har_filter_defaults_to_non_overwriting_output() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("capture.har");
+    let expected_output = tmp.path().join("capture.filtered.har");
+
+    fs::copy("tests/fixtures/simple.har", &input).unwrap();
+    let original = fs::read_to_string(&input).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--method",
+            "GET",
+        ])
+        .assert()
+        .success();
+
+    assert!(expected_output.exists());
+    let preserved = fs::read_to_string(&input).unwrap();
+    assert_eq!(preserved, original);
+}
+
+#[test]
 fn test_export_with_format_override_on_extensionless_input() {
     let tmp = TempDir::new().unwrap();
     let input = tmp.path().join("session");
@@ -1607,6 +1631,109 @@ fn test_export_with_format_override_on_extensionless_input() {
         .as_str()
         .expect("method should be set");
     assert_eq!(method, "GET");
+}
+
+#[test]
+fn test_export_time_filter_with_timezone_offsets() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("timezone.har");
+    let output = tmp.path().join("timezone.filtered.har");
+    let har = r#"{
+      "log": {
+        "version": "1.2",
+        "creator": {"name": "test", "version": "1.0"},
+        "entries": [
+          {
+            "startedDateTime": "2024-01-01T00:00:00-05:00",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://example.com/early",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 0,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          },
+          {
+            "startedDateTime": "2024-01-01T00:00:00Z",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://example.com/late",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 0,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          }
+        ]
+      }
+    }"#;
+
+    fs::write(&input, har).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--from",
+            "2024-01-01T04:00:00Z",
+        ])
+        .args(["--format", "har"])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success();
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&output).unwrap()).unwrap();
+    let entries = exported["log"]["entries"]
+        .as_array()
+        .expect("entries array should exist");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0]["request"]["url"].as_str().unwrap(),
+        "https://example.com/early"
+    );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -243,7 +243,14 @@ fn test_export_data_source_filter_no_match() {
         .success();
 
     harlite()
-        .args(["export-data", "--format", "jsonl", "--source", "missing.har", "-o"])
+        .args([
+            "export-data",
+            "--format",
+            "jsonl",
+            "--source",
+            "missing.har",
+            "-o",
+        ])
         .arg(&out_path)
         .arg(&db_path)
         .assert()
@@ -278,7 +285,10 @@ fn test_openapi_basic() {
         .read_to_string(&mut contents)
         .unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap();
-    assert_eq!(parsed.get("openapi").and_then(|v| v.as_str()), Some("3.0.3"));
+    assert_eq!(
+        parsed.get("openapi").and_then(|v| v.as_str()),
+        Some("3.0.3")
+    );
     assert!(parsed.get("paths").is_some());
 }
 
@@ -296,8 +306,7 @@ fn test_replay_har_with_override() {
                     Ok(0) => break,
                     Ok(n) => {
                         read_total += n;
-                        if read_total >= 4
-                            && buf[..read_total].windows(4).any(|w| w == b"\r\n\r\n")
+                        if read_total >= 4 && buf[..read_total].windows(4).any(|w| w == b"\r\n\r\n")
                         {
                             break;
                         }
@@ -309,7 +318,8 @@ fn test_replay_har_with_override() {
                 }
             }
 
-            let response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Type: text/plain\r\n\r\nOK";
+            let response =
+                b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Type: text/plain\r\n\r\nOK";
             let _ = stream.write_all(response);
         }
     });
@@ -357,7 +367,15 @@ fn test_replay_har_with_override() {
 
     let override_host = format!(".*=127.0.0.1:{}", addr.port());
     harlite()
-        .args(["replay", "--format", "json", "--method", "GET", "--concurrency", "1"])
+        .args([
+            "replay",
+            "--format",
+            "json",
+            "--method",
+            "GET",
+            "--concurrency",
+            "1",
+        ])
         .arg(&har_path)
         .args(["--override-host", &override_host])
         .assert()
@@ -1523,6 +1541,72 @@ fn test_export_roundtrip_with_bodies() {
         .query_row("SELECT COUNT(*) FROM blobs", [], |r| r.get(0))
         .unwrap();
     assert!(blob_count > 0);
+}
+
+#[test]
+fn test_export_direct_har_filter() {
+    let tmp = TempDir::new().unwrap();
+    let filtered_path = tmp.path().join("filtered.har");
+
+    harlite()
+        .args([
+            "export",
+            "tests/fixtures/simple.har",
+            "--method",
+            "POST",
+            "--bodies",
+        ])
+        .args(["-o"])
+        .arg(&filtered_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 1 entries"));
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&filtered_path).unwrap()).unwrap();
+    let entries = exported["log"]["entries"]
+        .as_array()
+        .expect("entries array should exist");
+    assert_eq!(entries.len(), 1);
+    let method = entries[0]["request"]["method"]
+        .as_str()
+        .expect("method should be set");
+    assert_eq!(method, "POST");
+}
+
+#[test]
+fn test_export_with_format_override_on_extensionless_input() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("session");
+    let output = tmp.path().join("session_filtered.har");
+
+    fs::copy("tests/fixtures/simple.har", &input).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--format",
+            "har",
+            "--method",
+            "GET",
+        ])
+        .args(["--bodies", "-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 1 entries"));
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&output).unwrap()).unwrap();
+    let entries = exported["log"]["entries"]
+        .as_array()
+        .expect("entries array should exist");
+    assert_eq!(entries.len(), 1);
+    let method = entries[0]["request"]["method"]
+        .as_str()
+        .expect("method should be set");
+    assert_eq!(method, "GET");
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1599,6 +1599,143 @@ fn test_export_har_filter_defaults_to_non_overwriting_output() {
 }
 
 #[test]
+fn test_export_db_defaults_to_current_directory_output() {
+    let tmp = TempDir::new().unwrap();
+    let stem = format!(
+        "issue119-export-default-{}",
+        tmp.path().file_name().unwrap().to_string_lossy()
+    );
+    let db_path = tmp.path().join(format!("{stem}.db"));
+    let expected_output = std::env::current_dir().unwrap().join(format!("{stem}.har"));
+    let _ = fs::remove_file(&expected_output);
+    let output_in_db_dir = tmp.path().join(format!("{stem}.har"));
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    harlite()
+        .args(["export", &db_path.to_string_lossy()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 2 entries"));
+
+    assert!(expected_output.exists());
+    assert!(!output_in_db_dir.exists());
+
+    let _ = fs::remove_file(&expected_output);
+}
+
+#[test]
+fn test_export_har_url_contains_is_case_insensitive() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("case-insensitive.har");
+    let output = tmp.path().join("case-insensitive.filtered.har");
+    let har = r#"{
+      "log": {
+        "version": "1.2",
+        "creator": {"name": "test", "version": "1.0"},
+        "entries": [
+          {
+            "startedDateTime": "2024-01-15T10:30:00.000Z",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/Users",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 0,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          },
+          {
+            "startedDateTime": "2024-01-15T10:30:01.000Z",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/notes",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 0,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          }
+        ]
+      }
+    }"#;
+
+    fs::write(&input, har).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--url-contains",
+            "users",
+            "--method",
+            "GET",
+        ])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 1 entries"));
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&output).unwrap()).unwrap();
+    let entries = exported["log"]["entries"]
+        .as_array()
+        .expect("entries array should exist");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0]["request"]["url"]
+            .as_str()
+            .expect("url should be set"),
+        "https://api.example.com/Users"
+    );
+}
+
+#[test]
 fn test_export_with_format_override_on_extensionless_input() {
     let tmp = TempDir::new().unwrap();
     let input = tmp.path().join("session");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1736,6 +1736,185 @@ fn test_export_har_url_contains_is_case_insensitive() {
 }
 
 #[test]
+fn test_export_har_omits_form_params_without_bodies() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("form-param.har");
+    let output = tmp.path().join("form-param.filtered.har");
+    let har = r#"{
+      "log": {
+        "version": "1.2",
+        "creator": {"name": "test", "version": "1.0"},
+        "entries": [
+          {
+            "startedDateTime": "2024-01-15T10:30:00.000Z",
+            "time": 10,
+            "request": {
+              "method": "POST",
+              "url": "https://api.example.com/login",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "postData": {
+                "mimeType": "application/x-www-form-urlencoded",
+                "text": "username=bob&password=secret",
+                "params": [
+                  {"name": "username", "value": "bob"},
+                  {"name": "password", "value": "secret"}
+                ]
+              },
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 13,
+                "mimeType": "text/plain",
+                "text": "logged in"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          }
+        ]
+      }
+    }"#;
+
+    fs::write(&input, har).unwrap();
+
+    harlite()
+        .args(["export", input.to_string_lossy().as_ref()])
+        .args(["--method", "POST"])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 1 entries"));
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&output).unwrap()).unwrap();
+    let entry = exported["log"]["entries"][0]
+        .as_object()
+        .expect("entry should be an object");
+    let request = entry["request"]
+        .as_object()
+        .expect("request should be an object");
+    let post_data = request["postData"]
+        .as_object()
+        .expect("postData should be set");
+    assert!(post_data.get("text").is_none() || post_data["text"].is_null());
+    assert!(post_data.get("params").is_none() || post_data["params"].is_null());
+}
+
+#[test]
+fn test_export_har_unknown_response_size_treated_as_zero_for_filtering() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("unknown-size.har");
+    let output = tmp.path().join("unknown-size.filtered.har");
+    let har = r#"{
+      "log": {
+        "version": "1.2",
+        "creator": {"name": "test", "version": "1.0"},
+        "entries": [
+          {
+            "startedDateTime": "2024-01-15T10:30:00.000Z",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/known",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": -1,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          },
+          {
+            "startedDateTime": "2024-01-15T10:30:01.000Z",
+            "time": 10,
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/small",
+              "httpVersion": "HTTP/1.1",
+              "headers": [],
+              "cookies": [],
+              "queryString": [],
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "httpVersion": "HTTP/1.1",
+              "cookies": [],
+              "headers": [],
+              "content": {
+                "size": 10,
+                "mimeType": "application/json",
+                "text": "{}"
+              },
+              "redirectURL": "",
+              "headersSize": 0,
+              "bodySize": 0
+            },
+            "cache": {},
+            "timings": {"send": 1, "wait": 1, "receive": 1}
+          }
+        ]
+      }
+    }"#;
+
+    fs::write(&input, har).unwrap();
+
+    harlite()
+        .args([
+            "export",
+            input.to_string_lossy().as_ref(),
+            "--min-response-size",
+            "0",
+        ])
+        .args(["--method", "GET"])
+        .args(["-o"])
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Exported 2 entries"));
+
+    let exported: serde_json::Value =
+        serde_json::from_reader(std::fs::File::open(&output).unwrap()).unwrap();
+    let entries = exported["log"]["entries"]
+        .as_array()
+        .expect("entries array should exist");
+    assert_eq!(entries.len(), 2);
+}
+
+#[test]
 fn test_export_with_format_override_on_extensionless_input() {
     let tmp = TempDir::new().unwrap();
     let input = tmp.path().join("session");


### PR DESCRIPTION
Fixes #119

## Summary
- Added export input format inference in `harlite export` so `db` inputs and `har` inputs are handled.
- Added `--format` override (`har|db`) so extension inference can be bypassed.
- Routed export filtering logic to operate directly on parsed HAR files when input is HAR.
- Kept `export` database path semantics unchanged for existing DB workflows.
- Reused and extended existing filter behavior (URL, host, method, status, sizes, time, MIME, ext, source)
  so direct HAR filtering produces the expected filtered HAR output.
- Added integration tests for direct HAR filtering and format override behavior on extensionless inputs.

## Testing
- `cargo check`
- `cargo test --test integration export`
