### PR TITLE
Harden untrusted input and sensitive data handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable Rust
+        run: |
+          rustup update stable
+          rustup default stable
+      - name: Test all features
+        run: cargo test --all-features --locked
+
+  security-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable Rust
+        run: |
+          rustup update stable
+          rustup default stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Audit locked dependencies
+        run: cargo audit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ Use the `harlite` binary to import HAR files into SQLite databases, then query/e
 
 ### `prune`
 - `--import-id <ID>`: import id to remove
+- `--allow-external-paths`: also delete external blob files (off by default)
+- `--external-path-root <DIR>`: restrict external file deletion to this root
 - `<DATABASE>`: database to modify
 
 ### `stats`
@@ -106,6 +108,14 @@ Use the `harlite` binary to import HAR files into SQLite databases, then query/e
 - `--body-regex <REGEX>`: body regex pattern (repeatable)
 - `--match <exact|wildcard|regex>`: pattern match mode
 - `--token <TOKEN>`: replacement token (default: `REDACTED`)
+- `--allow-external-paths`: read external body files (off by default)
+- `--external-path-root <DIR>`: restrict external body reads to this root
+
+### `pii`
+- `--redact`: write redacted findings back to the database
+- `-o, --output <OUTPUT>`: output database when redacting
+- `--allow-external-paths`: scan external body files (off by default)
+- `--external-path-root <DIR>`: restrict external body reads to this root
 
 ### `diff`
 - `<LEFT> <RIGHT>`: two HAR files or two databases to compare

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayref"
@@ -299,9 +299,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -309,14 +309,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -487,9 +488,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -1586,9 +1587,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
  "twox-hash",
 ]
@@ -2033,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2185,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap_complete = { version = "4", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 url = "2"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cargo build --release
 ./target/release/harlite --help
 ```
 
-Performance note: HAR parsing streams entries from disk using `serde_json::Deserializer` to avoid loading the full JSON blob at once; memory still scales with the number of entries imported. Use `--jobs` to parallelize across multiple HAR files (auto by default, capped to limit SQLite contention) and `--async-read` to read large files via a background reader thread (trades RAM for smoother throughput).
+Performance note: HAR parsing streams JSON from disk, but memory still scales with the number and size of entries imported. Decompressed input is capped at 512 MiB to bound compressed-file expansion. Embedders can choose a lower limit with `parse_har_file_with_limit`. Use `--jobs` to parallelize across multiple HAR files (auto by default, capped to limit SQLite contention) and `--async-read` to read large files via a background reader thread.
 
 ### Shell completions
 
@@ -245,7 +245,6 @@ name = "sample-filter"
 kind = "filter"
 command = "plugins/sample_filter.py"
 phase = "import"
-enabled = true
 
 [[plugins]]
 name = "sample-exporter"
@@ -253,6 +252,8 @@ kind = "exporter"
 command = "plugins/sample_exporter.py"
 phase = "export"
 ```
+
+For security, configuration only defines plugins; it never authorizes execution. Every plugin must be explicitly enabled with `--plugin` on each run. `enabled = false` can be used as an administrative deny switch.
 
 Enable/disable per run:
 
@@ -517,6 +518,10 @@ Remove a specific import and its entries/pages/blobs:
 
 ```bash
 harlite prune traffic.db --import-id 2
+
+# Also delete external body files, restricted to a trusted root
+harlite prune traffic.db --import-id 2 --allow-external-paths \
+  --external-path-root ./extracted-bodies
 ```
 
 ### Export HAR files
@@ -682,7 +687,7 @@ harlite replay capture.har --override-header 'Authorization=Bearer token'
 harlite replay capture.har --override-header 'example\\.com:Authorization=Bearer token'
 ```
 
-Safety: unsafe methods are skipped unless `--allow-unsafe` is set.
+Safety: unsafe methods are skipped unless `--allow-unsafe` is set. Automatic redirects are disabled so captured credentials and custom sensitive headers cannot be forwarded to another origin.
 
 ### Redact sensitive data
 
@@ -710,7 +715,13 @@ harlite redact traffic.db --query-param token --query-param session --match wild
 
 # Redact matching patterns in stored bodies (UTF-8 only)
 harlite redact traffic.db --body-regex '(?i)\"password\"\\s*:\\s*\"[^\"]+\"'
+
+# Read externally stored bodies only from an explicit trusted root
+harlite redact traffic.db --body-regex 'secret' --allow-external-paths \
+  --external-path-root ./extracted-bodies
 ```
+
+Redaction removes superseded blobs and compacts the database, including its WAL, so old values are not left in ordinary SQLite free pages. External body paths are ignored unless explicitly enabled and contained by the selected root.
 
 ### Scan for PII
 
@@ -728,6 +739,9 @@ harlite pii traffic.db --no-defaults --email-regex '(?i)\\b.+@example\\.com\\b'
 
 # Auto-redact findings (write a new DB)
 harlite pii traffic.db --redact --output traffic.redacted.db
+
+# Scan trusted externally stored bodies
+harlite pii traffic.db --allow-external-paths --external-path-root ./extracted-bodies
 ```
 
 Defaults are conservative but may still produce false positives; review results before redacting. Use `--no-defaults` to opt out and supply your own regexes.
@@ -750,6 +764,8 @@ harlite query "SELECT * FROM entries ORDER BY started_at" traffic.db --limit 100
 # If you omit the database path, harlite will use the only *.db in the current directory (if exactly one exists)
 harlite query "SELECT COUNT(*) AS entries FROM entries" --format json
 ```
+
+CSV fields beginning with spreadsheet formula characters are emitted as text to prevent formula execution when opened in spreadsheet applications.
 
 ### Interactive REPL
 

--- a/docs/plugin-developer-guide.md
+++ b/docs/plugin-developer-guide.md
@@ -24,7 +24,6 @@ name = "sample-filter"
 kind = "filter"
 command = "plugins/sample_filter.py"
 phase = "import"
-enabled = true
 
 [[plugins]]
 name = "sample-transform"
@@ -42,11 +41,12 @@ phase = "export"
 Notes:
 - `name` must be unique.
 - `command` can be absolute or relative to the current working directory.
-- `enabled = false` disables the plugin by default.
+- Plugin definitions are never executed implicitly. Each run must name the plugin with `--plugin`.
+- `enabled = false` is an administrative deny switch and prevents `--plugin` from enabling it.
 
 ## Enabling/disabling per run
 
-You can override config at runtime:
+Plugin execution must be authorized explicitly at runtime:
 
 ```bash
 harlite import capture.har --plugin sample-filter
@@ -178,7 +178,7 @@ Use stderr for debug logs; `harlite` does not parse stderr.
 
 ## Security considerations
 
-Plugins run as separate processes with the same permissions as `harlite`. Treat plugin code as trusted.
+Plugins run as separate processes with the same permissions as `harlite`. Treat plugin code as trusted. Project-local configuration may define plugins, but cannot execute them unless the command line explicitly enables their names.
 
 ## Sample plugins
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,10 +5,11 @@
 
 pub use crate::commands::{
     run_analyze, run_diff, run_export, run_export_data, run_fts_rebuild, run_import, run_imports,
-    run_info, run_merge, run_openapi, run_pii, run_prune, run_query, run_redact, run_report,
+    run_info, run_merge, run_openapi, run_pii, run_pii_with_external_paths, run_prune,
+    run_prune_with_options, run_query, run_redact, run_redact_with_external_paths, run_report,
     run_schema, run_search, run_stats, run_waterfall, AnalyzeOptions, DataExportFormat,
     DedupStrategy, DiffOptions, EntryFilterOptions, ExportDataOptions, ExportOptions, FtsTokenizer,
-    ImportOptions, InfoOptions, NameMatchMode, OpenApiOptions, OutputFormat, PiiOptions,
+    ImportOptions, InfoOptions, NameMatchMode, OpenApiOptions, OutputFormat, PiiOptions, PruneOptions,
     QueryOptions, RedactOptions, ReportOptions, StatsOptions, WaterfallFormat, WaterfallGroupBy,
     WaterfallOptions,
 };
@@ -34,9 +35,10 @@ pub use crate::db::{
 pub use crate::error::{HarliteError, Result};
 pub use crate::graphql::{extract_graphql_info, GraphQLInfo};
 pub use crate::har::{
-    parse_har_file, parse_har_file_async, Browser, Content, Cookie, Creator, Entry, Extensions,
-    Har, Header, Log, Page, PageTimings, PostData, PostParam, QueryParam, Request, Response,
-    Timings,
+    parse_har_file, parse_har_file_async, parse_har_file_async_with_limit,
+    parse_har_file_with_limit, Browser, Content, Cookie, Creator, Entry, Extensions, Har, Header,
+    Log, Page, PageTimings, PostData, PostParam, QueryParam, Request, Response, Timings,
+    DEFAULT_MAX_HAR_INPUT_BYTES,
 };
 pub use crate::plugins::{
     resolve_plugins, ExporterOutcome, PluginConfig, PluginContext, PluginKind, PluginPhase,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -311,6 +311,14 @@ pub enum Commands {
         /// Import id to remove
         #[arg(long)]
         import_id: i64,
+
+        /// Allow deleting external blob files (restricted to a root directory)
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        allow_external_paths: bool,
+
+        /// Root directory allowed for external blob file deletion
+        #[arg(long, requires = "allow_external_paths")]
+        external_path_root: Option<PathBuf>,
     },
 
     /// Show lightweight database stats (script-friendly)
@@ -940,6 +948,14 @@ pub enum Commands {
         #[arg(long)]
         token: Option<String>,
 
+        /// Allow reading external blob files (restricted to a root directory)
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        allow_external_paths: bool,
+
+        /// Root directory allowed for external blob file reads
+        #[arg(long, requires = "allow_external_paths")]
+        external_path_root: Option<PathBuf>,
+
         /// Database file to redact (default: the only *.db in the current directory)
         database: Option<PathBuf>,
     },
@@ -1005,6 +1021,14 @@ pub enum Commands {
         /// Replacement token to write for redacted values
         #[arg(long)]
         token: Option<String>,
+
+        /// Allow reading external blob files (restricted to a root directory)
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        allow_external_paths: bool,
+
+        /// Root directory allowed for external blob file reads
+        #[arg(long, requires = "allow_external_paths")]
+        external_path_root: Option<PathBuf>,
 
         /// Database file to scan (default: the only *.db in the current directory)
         database: Option<PathBuf>,

--- a/src/commands/csv.rs
+++ b/src/commands/csv.rs
@@ -1,0 +1,58 @@
+use std::io::Write;
+
+use crate::error::Result;
+
+/// Write one spreadsheet-safe CSV field.
+///
+/// RFC 4180 quoting alone does not prevent spreadsheet applications from
+/// evaluating attacker-controlled cells as formulas. Prefix suspicious fields
+/// with an apostrophe before applying normal CSV escaping.
+pub(crate) fn write_csv_field(out: &mut impl Write, field: &str) -> Result<()> {
+    let trimmed = field.trim_start_matches(|ch: char| ch.is_whitespace() || ch == '\u{feff}');
+    let formula = matches!(trimmed.chars().next(), Some('=' | '+' | '-' | '@'));
+
+    let must_quote = formula
+        || field.contains(',')
+        || field.contains('"')
+        || field.contains('\n')
+        || field.contains('\r');
+    if must_quote {
+        out.write_all(b"\"")?;
+    }
+    if formula {
+        out.write_all(b"'")?;
+    }
+    for ch in field.chars() {
+        if ch == '"' {
+            out.write_all(b"\"\"")?;
+        } else {
+            write!(out, "{ch}")?;
+        }
+    }
+    if must_quote {
+        out.write_all(b"\"")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_csv_field;
+
+    #[test]
+    fn neutralizes_spreadsheet_formulas_after_whitespace() {
+        for value in ["=1+1", "+cmd", "-cmd", "@SUM(A1:A2)", " \t=1+1"] {
+            let mut out = Vec::new();
+            write_csv_field(&mut out, value).unwrap();
+            let rendered = String::from_utf8(out).unwrap();
+            assert!(rendered.starts_with("\"'"), "{value:?}: {rendered:?}");
+        }
+    }
+
+    #[test]
+    fn escapes_quotes_and_delimiters() {
+        let mut out = Vec::new();
+        write_csv_field(&mut out, "a,\"b\"").unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "\"a,\"\"b\"\"\"");
+    }
+}

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -12,7 +12,7 @@ use crate::db::{load_entries, EntryQuery, EntryRow};
 use crate::error::{HarliteError, Result};
 use crate::har::{parse_har_file, Entry as HarEntry, Header};
 
-use super::OutputFormat;
+use super::{csv::write_csv_field, OutputFormat};
 
 pub struct DiffOptions {
     pub format: OutputFormat,
@@ -623,25 +623,6 @@ where
         write_csv_field(out, field)?;
     }
     out.write_all(b"\n")?;
-    Ok(())
-}
-
-fn write_csv_field(out: &mut impl Write, field: &str) -> Result<()> {
-    let needs_quotes = field.contains([',', '"', '\n', '\r']);
-    if !needs_quotes {
-        out.write_all(field.as_bytes())?;
-        return Ok(());
-    }
-
-    out.write_all(b"\"")?;
-    for b in field.as_bytes() {
-        if *b == b'"' {
-            out.write_all(b"\"\"")?;
-        } else {
-            out.write_all(&[*b])?;
-        }
-    }
-    out.write_all(b"\"")?;
     Ok(())
 }
 

--- a/src/commands/export_data.rs
+++ b/src/commands/export_data.rs
@@ -9,6 +9,7 @@ use crate::db::{ensure_schema_upgrades, EntryRow};
 use crate::error::{HarliteError, Result};
 
 use super::entry_filter::{load_entries_with_filters, EntryFilterOptions};
+use super::csv::write_csv_field;
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[clap(rename_all = "kebab-case")]
@@ -164,25 +165,6 @@ where
         write_csv_field(out, field)?;
     }
     out.write_all(b"\n")?;
-    Ok(())
-}
-
-fn write_csv_field(out: &mut impl Write, field: &str) -> Result<()> {
-    let needs_quotes = field.contains([',', '"', '\n', '\r']);
-    if !needs_quotes {
-        out.write_all(field.as_bytes())?;
-        return Ok(());
-    }
-
-    out.write_all(b"\"")?;
-    for b in field.as_bytes() {
-        if *b == b'"' {
-            out.write_all(b"\"\"")?;
-        } else {
-            out.write_all(&[*b])?;
-        }
-    }
-    out.write_all(b"\"")?;
     Ok(())
 }
 
@@ -389,7 +371,7 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
     use parquet::column::writer::ColumnWriter;
     use parquet::data_type::ByteArray;
     use parquet::file::properties::WriterProperties;
-    use parquet::file::writer::SerializedFileWriter;
+    use parquet::file::writer::{SerializedFileWriter, SerializedRowGroupWriter};
     use parquet::schema::types::Type;
     use std::sync::Arc;
 
@@ -397,196 +379,196 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
         .with_fields(vec![
             Type::primitive_type_builder("import_id", PhysicalType::INT64)
                 .with_repetition(Repetition::REQUIRED)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("page_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("started_at", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("time_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("blocked_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("dns_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("connect_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("send_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("wait_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("receive_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("ssl_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("method", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("url", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("host", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("path", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("query_string", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("http_version", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("request_headers", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("request_cookies", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("request_body_hash", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("request_body_size", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("status", PhysicalType::INT32)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("status_text", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_headers", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_cookies", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_body_hash", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_body_size", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_body_hash_raw", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_body_size_raw", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_mime_type", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("is_redirect", PhysicalType::INT32)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("server_ip", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("connection_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("request_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("parent_request_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("initiator_type", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("initiator_url", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("initiator_line", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("initiator_column", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("redirect_url", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("tls_version", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("tls_cipher_suite", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("tls_cert_subject", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("tls_cert_issuer", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("tls_cert_expiry", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("entry_hash", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("entry_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("request_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("response_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("content_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("timings_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
             Type::primitive_type_builder("post_data_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?,
+                .build()?.into(),
         ])
         .build()?;
 
@@ -596,15 +578,18 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
 
     let mut row_group_writer = writer.next_row_group()?;
 
-    let mut write_string_col = |values: Vec<Option<String>>| -> Result<()> {
+    fn write_string_col<W: std::io::Write + Send>(
+        row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
+        values: Vec<Option<String>>,
+    ) -> Result<()> {
         let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
         let data: Vec<ByteArray> = values
             .into_iter()
             .filter_map(|v| v.map(|s| ByteArray::from(s.into_bytes())))
             .collect();
-        if let Some(col_writer) = row_group_writer.next_column()? {
-            match col_writer {
-                ColumnWriter::ByteArrayColumnWriter(mut w) => {
+        if let Some(mut col_writer) = row_group_writer.next_column()? {
+            match col_writer.untyped() {
+                ColumnWriter::ByteArrayColumnWriter(w) => {
                     w.write_batch(&data, Some(&def_levels), None)?;
                 }
                 _ => {
@@ -613,16 +598,20 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
                     ))
                 }
             }
+            col_writer.close()?;
         }
         Ok(())
-    };
+    }
 
-    let mut write_i64_col = |values: Vec<Option<i64>>| -> Result<()> {
+    fn write_i64_col<W: std::io::Write + Send>(
+        row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
+        values: Vec<Option<i64>>,
+    ) -> Result<()> {
         let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
         let data: Vec<i64> = values.into_iter().filter_map(|v| v).collect();
-        if let Some(col_writer) = row_group_writer.next_column()? {
-            match col_writer {
-                ColumnWriter::Int64ColumnWriter(mut w) => {
+        if let Some(mut col_writer) = row_group_writer.next_column()? {
+            match col_writer.untyped() {
+                ColumnWriter::Int64ColumnWriter(w) => {
                     w.write_batch(&data, Some(&def_levels), None)?;
                 }
                 _ => {
@@ -631,16 +620,20 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
                     ))
                 }
             }
+            col_writer.close()?;
         }
         Ok(())
-    };
+    }
 
-    let mut write_i32_col = |values: Vec<Option<i32>>| -> Result<()> {
+    fn write_i32_col<W: std::io::Write + Send>(
+        row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
+        values: Vec<Option<i32>>,
+    ) -> Result<()> {
         let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
         let data: Vec<i32> = values.into_iter().filter_map(|v| v).collect();
-        if let Some(col_writer) = row_group_writer.next_column()? {
-            match col_writer {
-                ColumnWriter::Int32ColumnWriter(mut w) => {
+        if let Some(mut col_writer) = row_group_writer.next_column()? {
+            match col_writer.untyped() {
+                ColumnWriter::Int32ColumnWriter(w) => {
                     w.write_batch(&data, Some(&def_levels), None)?;
                 }
                 _ => {
@@ -649,16 +642,20 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
                     ))
                 }
             }
+            col_writer.close()?;
         }
         Ok(())
-    };
+    }
 
-    let mut write_f64_col = |values: Vec<Option<f64>>| -> Result<()> {
+    fn write_f64_col<W: std::io::Write + Send>(
+        row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
+        values: Vec<Option<f64>>,
+    ) -> Result<()> {
         let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
         let data: Vec<f64> = values.into_iter().filter_map(|v| v).collect();
-        if let Some(col_writer) = row_group_writer.next_column()? {
-            match col_writer {
-                ColumnWriter::DoubleColumnWriter(mut w) => {
+        if let Some(mut col_writer) = row_group_writer.next_column()? {
+            match col_writer.untyped() {
+                ColumnWriter::DoubleColumnWriter(w) => {
                     w.write_batch(&data, Some(&def_levels), None)?;
                 }
                 _ => {
@@ -667,15 +664,16 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
                     ))
                 }
             }
+            col_writer.close()?;
         }
         Ok(())
-    };
+    }
 
     let import_ids = entries.iter().map(|e| e.import_id).collect::<Vec<_>>();
     let import_def = vec![1; import_ids.len()];
-    if let Some(col_writer) = row_group_writer.next_column()? {
-        match col_writer {
-            ColumnWriter::Int64ColumnWriter(mut w) => {
+    if let Some(mut col_writer) = row_group_writer.next_column()? {
+        match col_writer.untyped() {
+            ColumnWriter::Int64ColumnWriter(w) => {
                 w.write_batch(&import_ids, Some(&import_def), None)?;
             }
             _ => {
@@ -684,59 +682,60 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
                 ))
             }
         }
+        col_writer.close()?;
     }
 
-    write_string_col(entries.iter().map(|e| e.page_id.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.started_at.clone()).collect())?;
-    write_f64_col(entries.iter().map(|e| e.time_ms).collect())?;
-    write_f64_col(entries.iter().map(|e| e.blocked_ms).collect())?;
-    write_f64_col(entries.iter().map(|e| e.dns_ms).collect())?;
-    write_f64_col(entries.iter().map(|e| e.connect_ms).collect())?;
-    write_f64_col(entries.iter().map(|e| e.send_ms).collect())?;
-    write_f64_col(entries.iter().map(|e| e.wait_ms).collect())?;
-    write_f64_col(entries.iter().map(|e| e.receive_ms).collect())?;
-    write_f64_col(entries.iter().map(|e| e.ssl_ms).collect())?;
-    write_string_col(entries.iter().map(|e| e.method.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.url.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.host.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.path.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.query_string.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.http_version.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.request_headers.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.request_cookies.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.request_body_hash.clone()).collect())?;
-    write_i64_col(entries.iter().map(|e| e.request_body_size).collect())?;
-    write_i32_col(entries.iter().map(|e| e.status).collect())?;
-    write_string_col(entries.iter().map(|e| e.status_text.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.response_headers.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.response_cookies.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.response_body_hash.clone()).collect())?;
-    write_i64_col(entries.iter().map(|e| e.response_body_size).collect())?;
-    write_string_col(entries.iter().map(|e| e.response_body_hash_raw.clone()).collect())?;
-    write_i64_col(entries.iter().map(|e| e.response_body_size_raw).collect())?;
-    write_string_col(entries.iter().map(|e| e.response_mime_type.clone()).collect())?;
-    write_i32_col(entries.iter().map(|e| e.is_redirect).collect())?;
-    write_string_col(entries.iter().map(|e| e.server_ip.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.connection_id.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.request_id.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.parent_request_id.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.initiator_type.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.initiator_url.clone()).collect())?;
-    write_i64_col(entries.iter().map(|e| e.initiator_line).collect())?;
-    write_i64_col(entries.iter().map(|e| e.initiator_column).collect())?;
-    write_string_col(entries.iter().map(|e| e.redirect_url.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.tls_version.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.tls_cipher_suite.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.tls_cert_subject.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.tls_cert_issuer.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.tls_cert_expiry.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.entry_hash.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.entry_extensions.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.request_extensions.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.response_extensions.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.content_extensions.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.timings_extensions.clone()).collect())?;
-    write_string_col(entries.iter().map(|e| e.post_data_extensions.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.page_id.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.started_at.clone()).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.time_ms).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.blocked_ms).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.dns_ms).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.connect_ms).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.send_ms).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.wait_ms).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.receive_ms).collect())?;
+    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.ssl_ms).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.method.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.url.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.host.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.path.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.query_string.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.http_version.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_headers.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_cookies.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_body_hash.clone()).collect())?;
+    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.request_body_size).collect())?;
+    write_i32_col(&mut row_group_writer, entries.iter().map(|e| e.status).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.status_text.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_headers.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_cookies.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_hash.clone()).collect())?;
+    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_size).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_hash_raw.clone()).collect())?;
+    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_size_raw).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_mime_type.clone()).collect())?;
+    write_i32_col(&mut row_group_writer, entries.iter().map(|e| e.is_redirect).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.server_ip.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.connection_id.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_id.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.parent_request_id.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_type.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_url.clone()).collect())?;
+    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_line).collect())?;
+    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_column).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.redirect_url.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_version.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cipher_suite.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cert_subject.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cert_issuer.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cert_expiry.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.entry_hash.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.entry_extensions.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_extensions.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_extensions.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.content_extensions.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.timings_extensions.clone()).collect())?;
+    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.post_data_extensions.clone()).collect())?;
 
     row_group_writer.close()?;
     writer.close()?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod diff;
 mod analyze;
+mod csv;
 mod entry_filter;
 mod export;
 mod export_data;
@@ -43,10 +44,10 @@ pub use merge::{run_merge, DedupStrategy, MergeOptions};
 #[cfg(feature = "otel")]
 pub use otel::{run_otel, OtelExportFormat, OtelExportOptions};
 pub use report::{run_report, ReportOptions};
-pub use prune::run_prune;
+pub use prune::{run_prune, run_prune_with_options, PruneOptions};
 pub use query::{run_query, OutputFormat, QueryOptions};
-pub use pii::{run_pii, PiiOptions};
-pub use redact::{run_redact, NameMatchMode, RedactOptions};
+pub use pii::{run_pii, run_pii_with_external_paths, PiiOptions};
+pub use redact::{run_redact, run_redact_with_external_paths, NameMatchMode, RedactOptions};
 #[cfg(feature = "repl")]
 pub use repl::{run_repl, ReplOptions};
 #[cfg(feature = "replay")]

--- a/src/commands/pii.rs
+++ b/src/commands/pii.rs
@@ -12,8 +12,8 @@ use crate::error::{HarliteError, Result};
 use super::csv::write_csv_field;
 use super::query::OutputFormat;
 use super::util::{
-    canonicalize_path_for_compare, finalize_sensitive_write, prepare_sensitive_write,
-    resolve_database, ExternalPathPolicy, StagedDatabase,
+    canonicalize_path_for_compare, delete_orphaned_blobs, finalize_sensitive_write,
+    prepare_sensitive_write, resolve_database, ExternalPathPolicy, StagedDatabase,
 };
 
 #[derive(Clone, Copy, Debug, serde::Serialize)]
@@ -378,6 +378,7 @@ pub fn run_pii_with_external_paths(
     drop(update);
     drop(stmt);
     if write {
+        delete_orphaned_blobs(work_conn)?;
         conn.execute_batch("COMMIT")?;
         finalize_sensitive_write(&conn)?;
     }

--- a/src/commands/pii.rs
+++ b/src/commands/pii.rs
@@ -9,11 +9,11 @@ use url::Url;
 use crate::db::store_blob;
 use crate::error::{HarliteError, Result};
 
-use super::query::OutputFormat;
 use super::csv::write_csv_field;
+use super::query::OutputFormat;
 use super::util::{
-    canonicalize_path_for_compare, copy_database_consistent, finalize_sensitive_write,
-    prepare_sensitive_write, remove_database_with_sidecars, resolve_database, ExternalPathPolicy,
+    canonicalize_path_for_compare, finalize_sensitive_write, prepare_sensitive_write,
+    resolve_database, ExternalPathPolicy, StagedDatabase,
 };
 
 #[derive(Clone, Copy, Debug, serde::Serialize)]
@@ -139,8 +139,16 @@ pub fn run_pii_with_external_paths(
         allow_external_paths,
         external_path_root,
     )?;
+
+    let matchers = build_matchers(options)?;
+    if matchers.is_empty() {
+        return Err(HarliteError::InvalidArgs(
+            "No PII patterns provided".to_string(),
+        ));
+    }
+
     let write = options.redact && !options.dry_run;
-    let target_db = if write {
+    let staged_output = if write {
         if let Some(out) = &options.output {
             let input_cmp = canonicalize_path_for_compare(&input_db)?;
             let out_cmp = canonicalize_path_for_compare(out)?;
@@ -155,22 +163,17 @@ pub fn run_pii_with_external_paths(
                     out.display()
                 )));
             }
-            remove_database_with_sidecars(out)?;
-            copy_database_consistent(&input_db, out)?;
-            out.clone()
+            Some(StagedDatabase::copy_from(&input_db, out, options.force)?)
         } else {
-            input_db.clone()
+            None
         }
     } else {
-        input_db.clone()
+        None
     };
-
-    let matchers = build_matchers(options)?;
-    if matchers.is_empty() {
-        return Err(HarliteError::InvalidArgs(
-            "No PII patterns provided".to_string(),
-        ));
-    }
+    let target_db = staged_output
+        .as_ref()
+        .map(|staged| staged.path().to_path_buf())
+        .unwrap_or_else(|| input_db.clone());
 
     let conn = if write {
         let conn = Connection::open(&target_db)?;
@@ -180,7 +183,12 @@ pub fn run_pii_with_external_paths(
         super::query::open_readonly_connection(&target_db)?
     };
 
-    let mut stmt = conn.prepare(
+    if write {
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+    }
+    let work_conn = &conn;
+
+    let mut stmt = work_conn.prepare(
         "SELECT id, url, query_string, request_body_hash, request_body_size, response_body_hash, response_body_size, response_body_hash_raw, response_body_size_raw FROM entries ORDER BY id",
     )?;
 
@@ -198,11 +206,11 @@ pub fn run_pii_with_external_paths(
         ))
     })?;
 
-    let mut update = conn.prepare(
+    let mut update = work_conn.prepare(
         "UPDATE entries SET url=?1, query_string=?2, request_body_hash=?3, request_body_size=?4, response_body_hash=?5, response_body_size=?6, response_body_hash_raw=?7, response_body_size_raw=?8 WHERE id=?9",
     )?;
 
-    let has_fts: bool = conn
+    let has_fts: bool = work_conn
         .query_row(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='response_body_fts'",
             [],
@@ -262,9 +270,7 @@ pub fn run_pii_with_external_paths(
         }
 
         if let Some(hash) = req_body_hash.as_deref() {
-            if let Some(text) =
-                load_blob_text(&conn, hash, &mut text_cache, &external_paths)?
-            {
+            if let Some(text) = load_blob_text(work_conn, hash, &mut text_cache, &external_paths)? {
                 append_findings(
                     &mut findings,
                     entry_id,
@@ -275,7 +281,7 @@ pub fn run_pii_with_external_paths(
 
                 if options.redact {
                     if let Some(redacted) = redact_blob_cached(
-                        &conn,
+                        work_conn,
                         hash,
                         &matchers,
                         &options.token,
@@ -292,9 +298,7 @@ pub fn run_pii_with_external_paths(
         }
 
         if let Some(hash) = resp_body_hash.as_deref() {
-            if let Some(text) =
-                load_blob_text(&conn, hash, &mut text_cache, &external_paths)?
-            {
+            if let Some(text) = load_blob_text(work_conn, hash, &mut text_cache, &external_paths)? {
                 append_findings(
                     &mut findings,
                     entry_id,
@@ -305,7 +309,7 @@ pub fn run_pii_with_external_paths(
 
                 if options.redact {
                     if let Some(redacted) = redact_blob_cached(
-                        &conn,
+                        work_conn,
                         hash,
                         &matchers,
                         &options.token,
@@ -322,7 +326,7 @@ pub fn run_pii_with_external_paths(
                         if write {
                             changed_response_hashes.insert(hash.to_string());
                             if has_fts {
-                                let has_old_fts = conn
+                                let has_old_fts = work_conn
                                     .query_row(
                                         "SELECT 1 FROM response_body_fts WHERE hash = ?1 LIMIT 1",
                                         params![hash],
@@ -331,7 +335,11 @@ pub fn run_pii_with_external_paths(
                                     .optional()?
                                     .is_some();
                                 if has_old_fts {
-                                    upsert_response_fts(&conn, &redacted.new_hash, &redacted.text)?;
+                                    upsert_response_fts(
+                                        work_conn,
+                                        &redacted.new_hash,
+                                        &redacted.text,
+                                    )?;
                                 }
                             }
                         }
@@ -357,8 +365,8 @@ pub fn run_pii_with_external_paths(
 
     if write && has_fts && !changed_response_hashes.is_empty() {
         let mut check_stmt =
-            conn.prepare("SELECT COUNT(*) FROM entries WHERE response_body_hash = ?1")?;
-        let mut delete_stmt = conn.prepare("DELETE FROM response_body_fts WHERE hash = ?1")?;
+            work_conn.prepare("SELECT COUNT(*) FROM entries WHERE response_body_hash = ?1")?;
+        let mut delete_stmt = work_conn.prepare("DELETE FROM response_body_fts WHERE hash = ?1")?;
         for hash in changed_response_hashes {
             let count: i64 = check_stmt.query_row([hash.as_str()], |row| row.get(0))?;
             if count == 0 {
@@ -370,7 +378,13 @@ pub fn run_pii_with_external_paths(
     drop(update);
     drop(stmt);
     if write {
+        conn.execute_batch("COMMIT")?;
         finalize_sensitive_write(&conn)?;
+    }
+    drop(conn);
+
+    if let Some(staged) = staged_output {
+        staged.publish()?;
     }
 
     match options.format {

--- a/src/commands/pii.rs
+++ b/src/commands/pii.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use regex::{NoExpand, Regex};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -10,7 +10,11 @@ use crate::db::store_blob;
 use crate::error::{HarliteError, Result};
 
 use super::query::OutputFormat;
-use super::util::{canonicalize_path_for_compare, resolve_database};
+use super::csv::write_csv_field;
+use super::util::{
+    canonicalize_path_for_compare, copy_database_consistent, finalize_sensitive_write,
+    prepare_sensitive_write, remove_database_with_sidecars, resolve_database, ExternalPathPolicy,
+};
 
 #[derive(Clone, Copy, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -101,6 +105,16 @@ struct PiiRedactedBlob {
 }
 
 pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
+    run_pii_with_external_paths(database, options, false, None)
+}
+
+/// Scan/redact PII with an explicit policy for externally stored bodies.
+pub fn run_pii_with_external_paths(
+    database: Option<PathBuf>,
+    options: &PiiOptions,
+    allow_external_paths: bool,
+    external_path_root: Option<&Path>,
+) -> Result<()> {
     if !options.redact {
         if options.output.is_some() {
             return Err(HarliteError::InvalidArgs(
@@ -120,6 +134,11 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
     }
 
     let input_db = resolve_database(database)?;
+    let external_paths = ExternalPathPolicy::new(
+        &input_db,
+        allow_external_paths,
+        external_path_root,
+    )?;
     let write = options.redact && !options.dry_run;
     let target_db = if write {
         if let Some(out) = &options.output {
@@ -136,10 +155,8 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
                     out.display()
                 )));
             }
-            if out.exists() {
-                std::fs::remove_file(out)?;
-            }
-            std::fs::copy(&input_db, out)?;
+            remove_database_with_sidecars(out)?;
+            copy_database_consistent(&input_db, out)?;
             out.clone()
         } else {
             input_db.clone()
@@ -157,7 +174,7 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
 
     let conn = if write {
         let conn = Connection::open(&target_db)?;
-        conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+        prepare_sensitive_write(&conn)?;
         conn
     } else {
         super::query::open_readonly_connection(&target_db)?
@@ -245,7 +262,9 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
         }
 
         if let Some(hash) = req_body_hash.as_deref() {
-            if let Some(text) = load_blob_text(&conn, hash, &mut text_cache)? {
+            if let Some(text) =
+                load_blob_text(&conn, hash, &mut text_cache, &external_paths)?
+            {
                 append_findings(
                     &mut findings,
                     entry_id,
@@ -262,6 +281,7 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
                         &options.token,
                         write,
                         &mut redacted_cache,
+                        &external_paths,
                     )? {
                         new_req_body_hash = Some(redacted.new_hash);
                         new_req_body_size = Some(redacted.new_size);
@@ -272,7 +292,9 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
         }
 
         if let Some(hash) = resp_body_hash.as_deref() {
-            if let Some(text) = load_blob_text(&conn, hash, &mut text_cache)? {
+            if let Some(text) =
+                load_blob_text(&conn, hash, &mut text_cache, &external_paths)?
+            {
                 append_findings(
                     &mut findings,
                     entry_id,
@@ -289,6 +311,7 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
                         &options.token,
                         write,
                         &mut redacted_cache,
+                        &external_paths,
                     )? {
                         new_resp_body_hash = Some(redacted.new_hash.clone());
                         new_resp_body_size = Some(redacted.new_size);
@@ -342,6 +365,12 @@ pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
                 delete_stmt.execute([hash])?;
             }
         }
+    }
+
+    drop(update);
+    drop(stmt);
+    if write {
+        finalize_sensitive_write(&conn)?;
     }
 
     match options.format {
@@ -489,12 +518,13 @@ fn load_blob_text(
     conn: &Connection,
     hash: &str,
     cache: &mut HashMap<String, Option<String>>,
+    external_paths: &ExternalPathPolicy,
 ) -> Result<Option<String>> {
     if let Some(existing) = cache.get(hash) {
         return Ok(existing.clone());
     }
 
-    let Some((content, _mime_type)) = load_blob_for_pii(conn, hash)? else {
+    let Some((content, _mime_type)) = load_blob_for_pii(conn, hash, external_paths)? else {
         cache.insert(hash.to_string(), None);
         return Ok(None);
     };
@@ -511,7 +541,11 @@ fn load_blob_text(
     Ok(Some(text))
 }
 
-fn load_blob_for_pii(conn: &Connection, hash: &str) -> Result<Option<(Vec<u8>, Option<String>)>> {
+fn load_blob_for_pii(
+    conn: &Connection,
+    hash: &str,
+    external_paths: &ExternalPathPolicy,
+) -> Result<Option<(Vec<u8>, Option<String>)>> {
     let row = conn
         .query_row(
             "SELECT content, size, mime_type, external_path FROM blobs WHERE hash = ?1",
@@ -533,7 +567,8 @@ fn load_blob_for_pii(conn: &Connection, hash: &str) -> Result<Option<(Vec<u8>, O
 
     if content.is_empty() && size > 0 {
         if let Some(path) = external_path {
-            if let Ok(bytes) = std::fs::read(path) {
+            if let Some(path) = external_paths.resolve_file(&path) {
+                let bytes = std::fs::read(path)?;
                 content = bytes;
             }
         }
@@ -553,12 +588,13 @@ fn redact_blob_cached(
     token: &str,
     write: bool,
     cache: &mut HashMap<String, Option<PiiRedactedBlob>>,
+    external_paths: &ExternalPathPolicy,
 ) -> Result<Option<PiiRedactedBlob>> {
     if let Some(existing) = cache.get(hash) {
         return Ok(existing.clone());
     }
 
-    let Some((content, mime_type)) = load_blob_for_pii(conn, hash)? else {
+    let Some((content, mime_type)) = load_blob_for_pii(conn, hash, external_paths)? else {
         cache.insert(hash.to_string(), None);
         return Ok(None);
     };
@@ -764,23 +800,6 @@ where
         write_csv_field(out, field)?;
     }
     out.write_all(b"\n")?;
-    Ok(())
-}
-
-fn write_csv_field(out: &mut impl Write, field: &str) -> Result<()> {
-    if field.contains(',') || field.contains('"') || field.contains('\n') {
-        out.write_all(b"\"")?;
-        for ch in field.chars() {
-            if ch == '"' {
-                out.write_all(b"\"\"")?;
-            } else {
-                out.write_all(ch.to_string().as_bytes())?;
-            }
-        }
-        out.write_all(b"\"")?;
-    } else {
-        out.write_all(field.as_bytes())?;
-    }
     Ok(())
 }
 

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -5,15 +5,35 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::error::{HarliteError, Result};
 
+use super::util::{prepare_sensitive_write, ExternalPathPolicy};
+
 const HASH_CHUNK: usize = 500;
+
+#[derive(Clone, Debug, Default)]
+pub struct PruneOptions {
+    pub allow_external_paths: bool,
+    pub external_path_root: Option<PathBuf>,
+}
 
 /// Remove all records for a specific import and prune orphaned blobs.
 pub fn run_prune(database: PathBuf, import_id: i64) -> Result<()> {
+    run_prune_with_options(database, import_id, &PruneOptions::default())
+}
+
+/// Remove all records for a specific import with an explicit policy for
+/// deleting external blob files.
+pub fn run_prune_with_options(
+    database: PathBuf,
+    import_id: i64,
+    options: &PruneOptions,
+) -> Result<()> {
+    let external_path_policy = ExternalPathPolicy::new(
+        &database,
+        options.allow_external_paths,
+        options.external_path_root.as_deref(),
+    )?;
     let conn = Connection::open(&database)?;
-    let external_root = database
-        .parent()
-        .map(|p| p.to_path_buf())
-        .and_then(|p| p.canonicalize().ok());
+    prepare_sensitive_write(&conn)?;
 
     let import_exists: Option<String> = conn
         .query_row(
@@ -115,29 +135,14 @@ pub fn run_prune(database: PathBuf, import_id: i64) -> Result<()> {
                 .collect();
 
             for raw_path in external_paths {
-                let candidate = PathBuf::from(&raw_path);
-                let resolved = if candidate.is_absolute() {
-                    candidate.canonicalize().ok()
-                } else if let Some(root) = external_root.as_ref() {
-                    let joined = root.join(&candidate);
-                    let resolved = joined.canonicalize().ok();
-                    if let Some(resolved_path) = resolved.as_ref() {
-                        if !resolved_path.starts_with(root) {
-                            external_skipped += 1;
-                            continue;
-                        }
-                    }
-                    resolved
-                } else {
+                let Some(path) = external_path_policy.resolve_file(&raw_path) else {
                     external_skipped += 1;
                     continue;
                 };
-
-                let Some(path) = resolved else {
-                    continue;
-                };
-                if path.is_file() && fs::remove_file(&path).is_ok() {
+                if fs::remove_file(&path).is_ok() {
                     external_deleted += 1;
+                } else {
+                    external_skipped += 1;
                 }
             }
 

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -65,6 +65,18 @@ pub fn run_prune_with_options(
         hashes
     };
 
+    let has_graphql_fields: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='graphql_fields')",
+        [],
+        |row| row.get(0),
+    )?;
+    if has_graphql_fields {
+        tx.execute(
+            "DELETE FROM graphql_fields WHERE entry_id IN (SELECT id FROM entries WHERE import_id = ?1)",
+            params![import_id],
+        )?;
+    }
+
     let entries_deleted = tx.execute(
         "DELETE FROM entries WHERE import_id = ?1",
         params![import_id],

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
@@ -88,6 +89,7 @@ pub fn run_prune_with_options(
     let mut fts_deleted = 0usize;
     let mut external_deleted = 0usize;
     let mut external_skipped = 0usize;
+    let mut external_delete_candidates: HashSet<PathBuf> = HashSet::new();
 
     if !hashes.is_empty() {
         let has_fts: i64 = tx.query_row(
@@ -151,11 +153,7 @@ pub fn run_prune_with_options(
                     external_skipped += 1;
                     continue;
                 };
-                if fs::remove_file(&path).is_ok() {
-                    external_deleted += 1;
-                } else {
-                    external_skipped += 1;
-                }
+                external_delete_candidates.insert(path);
             }
 
             if has_fts > 0 {
@@ -169,7 +167,28 @@ pub fn run_prune_with_options(
         }
     }
 
+    let external_paths_in_use: HashSet<PathBuf> = if external_delete_candidates.is_empty() {
+        HashSet::new()
+    } else {
+        let mut stmt =
+            tx.prepare("SELECT DISTINCT external_path FROM blobs WHERE external_path IS NOT NULL")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        rows.filter_map(|row| row.ok())
+            .filter_map(|raw_path| external_path_policy.resolve_file(&raw_path))
+            .collect()
+    };
+
     tx.commit()?;
+
+    for path in external_delete_candidates {
+        if external_paths_in_use.contains(&path) {
+            external_skipped += 1;
+        } else if fs::remove_file(&path).is_ok() {
+            external_deleted += 1;
+        } else {
+            external_skipped += 1;
+        }
+    }
 
     println!(
         "Pruned import {import_id} ({source_file}). Removed {imports_deleted} import record, {entries_deleted} entries, {pages_deleted} pages, {blobs_deleted} blobs, {fts_deleted} FTS rows, deleted {external_deleted} external files (skipped {external_skipped})."

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -61,8 +61,7 @@ pub fn run_prune_with_options(
         )?;
         let hashes = stmt
             .query_map(params![import_id], |row| row.get(0))?
-            .filter_map(|row| row.ok())
-            .collect();
+            .collect::<rusqlite::Result<Vec<_>>>()?;
         hashes
     };
 
@@ -123,8 +122,7 @@ pub fn run_prune_with_options(
             let orphan_hashes: Vec<String> = tx
                 .prepare(&sql_orphans)?
                 .query_map(params_vec.as_slice(), |row| row.get(0))?
-                .filter_map(|row| row.ok())
-                .collect();
+                .collect::<rusqlite::Result<Vec<_>>>()?;
 
             if orphan_hashes.is_empty() {
                 continue;
@@ -145,8 +143,7 @@ pub fn run_prune_with_options(
                     "SELECT external_path FROM blobs WHERE hash IN ({orphan_placeholders}) AND external_path IS NOT NULL"
                 ))?
                 .query_map(orphan_params.as_slice(), |row| row.get(0))?
-                .filter_map(|row| row.ok())
-                .collect();
+                .collect::<rusqlite::Result<Vec<_>>>()?;
 
             for raw_path in external_paths {
                 let Some(path) = external_path_policy.resolve_file(&raw_path) else {

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -173,9 +173,14 @@ pub fn run_prune_with_options(
         let mut stmt =
             tx.prepare("SELECT DISTINCT external_path FROM blobs WHERE external_path IS NOT NULL")?;
         let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-        rows.filter_map(|row| row.ok())
-            .filter_map(|raw_path| external_path_policy.resolve_file(&raw_path))
-            .collect()
+        let mut paths = HashSet::new();
+        for row in rows {
+            let raw_path = row?;
+            if let Some(path) = external_path_policy.resolve_file(&raw_path) {
+                paths.insert(path);
+            }
+        }
+        paths
     };
 
     tx.commit()?;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -7,6 +7,7 @@ use rusqlite::{params_from_iter, Connection, OpenFlags};
 
 use crate::error::{HarliteError, Result};
 
+use super::csv::write_csv_field;
 use super::util::resolve_database;
 
 #[derive(Clone, Copy, Debug, ValueEnum, serde::Serialize, serde::Deserialize)]
@@ -208,25 +209,6 @@ where
         write_csv_field(out, field)?;
     }
     out.write_all(b"\n")?;
-    Ok(())
-}
-
-fn write_csv_field(out: &mut impl Write, field: &str) -> Result<()> {
-    let needs_quotes = field.contains([',', '"', '\n', '\r']);
-    if !needs_quotes {
-        out.write_all(field.as_bytes())?;
-        return Ok(());
-    }
-
-    out.write_all(b"\"")?;
-    for b in field.as_bytes() {
-        if *b == b'"' {
-            out.write_all(b"\"\"")?;
-        } else {
-            out.write_all(&[*b])?;
-        }
-    }
-    out.write_all(b"\"")?;
     Ok(())
 }
 

--- a/src/commands/redact.rs
+++ b/src/commands/redact.rs
@@ -10,8 +10,8 @@ use crate::db::store_blob;
 use crate::error::{HarliteError, Result};
 
 use super::util::{
-    canonicalize_path_for_compare, finalize_sensitive_write, prepare_sensitive_write,
-    resolve_database, ExternalPathPolicy, StagedDatabase,
+    canonicalize_path_for_compare, delete_orphaned_blobs, finalize_sensitive_write,
+    prepare_sensitive_write, resolve_database, ExternalPathPolicy, StagedDatabase,
 };
 
 #[derive(Clone, Copy, Debug, ValueEnum, serde::Serialize, serde::Deserialize)]
@@ -865,6 +865,7 @@ pub fn run_redact_with_external_paths(
             true,
             &external_paths,
         )?;
+        delete_orphaned_blobs(&tx)?;
         tx.commit()?;
         finalize_sensitive_write(&conn)?;
         report

--- a/src/commands/redact.rs
+++ b/src/commands/redact.rs
@@ -10,8 +10,8 @@ use crate::db::store_blob;
 use crate::error::{HarliteError, Result};
 
 use super::util::{
-    canonicalize_path_for_compare, copy_database_consistent, finalize_sensitive_write,
-    prepare_sensitive_write, remove_database_with_sidecars, resolve_database, ExternalPathPolicy,
+    canonicalize_path_for_compare, finalize_sensitive_write, prepare_sensitive_write,
+    resolve_database, ExternalPathPolicy, StagedDatabase,
 };
 
 #[derive(Clone, Copy, Debug, ValueEnum, serde::Serialize, serde::Deserialize)]
@@ -771,29 +771,6 @@ pub fn run_redact_with_external_paths(
         external_path_root,
     )?;
 
-    let target_db = if options.dry_run {
-        input_db.clone()
-    } else if let Some(out) = &options.output {
-        let input_cmp = canonicalize_path_for_compare(&input_db)?;
-        let out_cmp = canonicalize_path_for_compare(out)?;
-        if out_cmp == input_cmp {
-            return Err(HarliteError::InvalidArgs(
-                "Output database must be different from input database".to_string(),
-            ));
-        }
-        if out.exists() && !options.force {
-            return Err(HarliteError::InvalidArgs(format!(
-                "Output database already exists: {} (use --force to overwrite)",
-                out.display()
-            )));
-        }
-        remove_database_with_sidecars(out)?;
-        copy_database_consistent(&input_db, out)?;
-        out.clone()
-    } else {
-        input_db.clone()
-    };
-
     let mut header_patterns: Vec<String> = Vec::new();
     let mut cookie_patterns: Vec<String> = Vec::new();
     let mut query_patterns: Vec<String> = Vec::new();
@@ -832,6 +809,31 @@ pub fn run_redact_with_external_paths(
         )));
     }
 
+    let staged_output = if options.dry_run {
+        None
+    } else if let Some(out) = &options.output {
+        let input_cmp = canonicalize_path_for_compare(&input_db)?;
+        let out_cmp = canonicalize_path_for_compare(out)?;
+        if out_cmp == input_cmp {
+            return Err(HarliteError::InvalidArgs(
+                "Output database must be different from input database".to_string(),
+            ));
+        }
+        if out.exists() && !options.force {
+            return Err(HarliteError::InvalidArgs(format!(
+                "Output database already exists: {} (use --force to overwrite)",
+                out.display()
+            )));
+        }
+        Some(StagedDatabase::copy_from(&input_db, out, options.force)?)
+    } else {
+        None
+    };
+    let target_db = staged_output
+        .as_ref()
+        .map(|staged| staged.path().to_path_buf())
+        .unwrap_or_else(|| input_db.clone());
+
     let mut conn = if options.dry_run {
         super::query::open_readonly_connection(&target_db)?
     } else {
@@ -867,6 +869,13 @@ pub fn run_redact_with_external_paths(
         finalize_sensitive_write(&conn)?;
         report
     };
+    drop(conn);
+
+    let result_db = if let Some(staged) = staged_output {
+        staged.publish()?
+    } else {
+        target_db
+    };
 
     if options.dry_run {
         println!(
@@ -885,7 +894,7 @@ pub fn run_redact_with_external_paths(
             "Redacted {} values across {} entries in {}",
             report.total(),
             report.entries_changed,
-            target_db.display()
+            result_db.display()
         );
     }
 

--- a/src/commands/redact.rs
+++ b/src/commands/redact.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::ValueEnum;
 use regex::{NoExpand, Regex, RegexBuilder};
@@ -10,7 +9,10 @@ use url::Url;
 use crate::db::store_blob;
 use crate::error::{HarliteError, Result};
 
-use super::util::{canonicalize_path_for_compare, resolve_database};
+use super::util::{
+    canonicalize_path_for_compare, copy_database_consistent, finalize_sensitive_write,
+    prepare_sensitive_write, remove_database_with_sidecars, resolve_database, ExternalPathPolicy,
+};
 
 #[derive(Clone, Copy, Debug, ValueEnum, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -315,6 +317,7 @@ fn redact_body_text(text: &str, regexes: &[Regex], token: &str) -> Option<(Strin
 fn load_blob_for_redaction(
     conn: &Connection,
     hash: &str,
+    external_paths: &ExternalPathPolicy,
 ) -> Result<Option<(Vec<u8>, Option<String>)>> {
     let row = conn
         .query_row(
@@ -337,7 +340,8 @@ fn load_blob_for_redaction(
 
     if content.is_empty() && size > 0 {
         if let Some(path) = external_path {
-            if let Ok(bytes) = std::fs::read(path) {
+            if let Some(path) = external_paths.resolve_file(&path) {
+                let bytes = std::fs::read(path)?;
                 content = bytes;
             }
         }
@@ -357,12 +361,13 @@ fn redact_blob_cached(
     token: &str,
     write: bool,
     cache: &mut HashMap<String, Option<RedactedBlob>>,
+    external_paths: &ExternalPathPolicy,
 ) -> Result<(Option<RedactedBlob>, bool)> {
     if let Some(existing) = cache.get(hash) {
         return Ok((existing.clone(), false));
     }
 
-    let Some((content, mime_type)) = load_blob_for_redaction(conn, hash)? else {
+    let Some((content, mime_type)) = load_blob_for_redaction(conn, hash, external_paths)? else {
         cache.insert(hash.to_string(), None);
         return Ok((None, true));
     };
@@ -506,6 +511,7 @@ fn redact_entries(
     body_regexes: &[Regex],
     token: &str,
     write: bool,
+    external_paths: &ExternalPathPolicy,
 ) -> Result<RedactionReport> {
     let mut stmt = conn.prepare(
         "SELECT id, url, query_string, request_headers, response_headers, request_cookies, response_cookies, request_body_hash, request_body_size, response_body_hash, response_body_size, response_body_hash_raw, response_body_size_raw FROM entries ORDER BY id",
@@ -648,7 +654,15 @@ fn redact_entries(
         if !body_regexes.is_empty() {
             if let Some(hash) = req_body_hash.as_deref() {
                 let (redacted, counted) =
-                    redact_blob_cached(conn, hash, body_regexes, token, write, &mut blob_cache)?;
+                    redact_blob_cached(
+                        conn,
+                        hash,
+                        body_regexes,
+                        token,
+                        write,
+                        &mut blob_cache,
+                        external_paths,
+                    )?;
                 if let Some(redacted) = redacted {
                     if counted {
                         report.body_matches += redacted.matches;
@@ -663,7 +677,15 @@ fn redact_entries(
             }
             if let Some(hash) = resp_body_hash.as_deref() {
                 let (redacted, counted) =
-                    redact_blob_cached(conn, hash, body_regexes, token, write, &mut blob_cache)?;
+                    redact_blob_cached(
+                        conn,
+                        hash,
+                        body_regexes,
+                        token,
+                        write,
+                        &mut blob_cache,
+                        external_paths,
+                    )?;
                 if let Some(redacted) = redacted {
                     if counted {
                         report.body_matches += redacted.matches;
@@ -732,7 +754,22 @@ fn redact_entries(
 }
 
 pub fn run_redact(database: Option<PathBuf>, options: &RedactOptions) -> Result<()> {
+    run_redact_with_external_paths(database, options, false, None)
+}
+
+/// Redact a database with an explicit policy for externally stored bodies.
+pub fn run_redact_with_external_paths(
+    database: Option<PathBuf>,
+    options: &RedactOptions,
+    allow_external_paths: bool,
+    external_path_root: Option<&Path>,
+) -> Result<()> {
     let input_db = resolve_database(database)?;
+    let external_paths = ExternalPathPolicy::new(
+        &input_db,
+        allow_external_paths,
+        external_path_root,
+    )?;
 
     let target_db = if options.dry_run {
         input_db.clone()
@@ -750,10 +787,8 @@ pub fn run_redact(database: Option<PathBuf>, options: &RedactOptions) -> Result<
                 out.display()
             )));
         }
-        if out.exists() {
-            fs::remove_file(out)?;
-        }
-        fs::copy(&input_db, out)?;
+        remove_database_with_sidecars(out)?;
+        copy_database_consistent(&input_db, out)?;
         out.clone()
     } else {
         input_db.clone()
@@ -797,8 +832,13 @@ pub fn run_redact(database: Option<PathBuf>, options: &RedactOptions) -> Result<
         )));
     }
 
-    let mut conn = Connection::open(&target_db)?;
-    conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+    let mut conn = if options.dry_run {
+        super::query::open_readonly_connection(&target_db)?
+    } else {
+        let conn = Connection::open(&target_db)?;
+        prepare_sensitive_write(&conn)?;
+        conn
+    };
 
     let report = if options.dry_run {
         redact_entries(
@@ -809,6 +849,7 @@ pub fn run_redact(database: Option<PathBuf>, options: &RedactOptions) -> Result<
             &body_regexes,
             &options.token,
             false,
+            &external_paths,
         )?
     } else {
         let tx = conn.transaction()?;
@@ -820,8 +861,10 @@ pub fn run_redact(database: Option<PathBuf>, options: &RedactOptions) -> Result<
             &body_regexes,
             &options.token,
             true,
+            &external_paths,
         )?;
         tx.commit()?;
+        finalize_sensitive_write(&conn)?;
         report
     };
 

--- a/src/commands/replay.rs
+++ b/src/commands/replay.rs
@@ -14,7 +14,7 @@ use crate::db::{ensure_schema_upgrades, load_blobs_by_hashes, load_entries, Blob
 use crate::error::{HarliteError, Result};
 use crate::har::{parse_har_file, Entry as HarEntry, Header, PostData};
 
-use super::OutputFormat;
+use super::{csv::write_csv_field, OutputFormat};
 
 pub struct ReplayOptions {
     pub format: OutputFormat,
@@ -219,7 +219,9 @@ fn worker_loop(
 }
 
 fn build_agent(timeout: Option<Duration>) -> ureq::Agent {
-    let mut builder = ureq::AgentBuilder::new();
+    // Captured requests may contain API keys or other non-standard sensitive
+    // headers. Never forward them through an automatic cross-origin redirect.
+    let mut builder = ureq::AgentBuilder::new().redirects(0);
     if let Some(timeout) = timeout {
         builder = builder.timeout_connect(timeout).timeout_read(timeout);
     }
@@ -954,25 +956,6 @@ where
     Ok(())
 }
 
-fn write_csv_field(out: &mut impl Write, field: &str) -> Result<()> {
-    let needs_quotes = field.contains([',', '"', '\n', '\r']);
-    if !needs_quotes {
-        out.write_all(field.as_bytes())?;
-        return Ok(());
-    }
-
-    out.write_all(b"\"")?;
-    for b in field.as_bytes() {
-        if *b == b'"' {
-            out.write_all(b"\"\"")?;
-        } else {
-            out.write_all(&[*b])?;
-        }
-    }
-    out.write_all(b"\"")?;
-    Ok(())
-}
-
 fn write_table_row<'a, I>(out: &mut impl Write, fields: I, widths: &[usize]) -> Result<()>
 where
     I: IntoIterator<Item = &'a str>,
@@ -1026,4 +1009,45 @@ fn truncate(s: &str, max: usize) -> String {
     let mut out = s[..end].to_string();
     out.push_str("...");
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_agent;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    #[test]
+    fn replay_agent_does_not_follow_redirects() {
+        let redirect_target = TcpListener::bind("127.0.0.1:0").unwrap();
+        redirect_target.set_nonblocking(true).unwrap();
+        let target_addr = redirect_target.local_addr().unwrap();
+
+        let redirect_source = TcpListener::bind("127.0.0.1:0").unwrap();
+        let source_addr = redirect_source.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = redirect_source.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 302 Found\r\nLocation: http://{target_addr}/secret\r\nContent-Length: 0\r\n\r\n"
+            )
+            .unwrap();
+        });
+
+        let response = build_agent(None)
+            .get(&format!("http://{source_addr}/start"))
+            .set("X-Api-Key", "secret")
+            .call();
+        let status = match response {
+            Ok(response) => response.status(),
+            Err(ureq::Error::Status(status, _)) => status,
+            Err(err) => panic!("unexpected replay error: {err}"),
+        };
+        assert_eq!(status, 302);
+        server.join().unwrap();
+        assert!(redirect_target.accept().is_err());
+    }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -7,6 +7,7 @@ use rusqlite::{params_from_iter, Connection, OpenFlags};
 
 use crate::error::{HarliteError, Result};
 
+use super::csv::write_csv_field;
 use super::query::{OutputFormat, QueryOptions};
 use super::util::resolve_database;
 
@@ -159,25 +160,6 @@ fn write_table(columns: &[&str], rows: &mut rusqlite::Rows<'_>, quiet: bool) -> 
         }
         write_table_row(&mut out, fields.iter().map(|s| s.as_str()), &widths)?;
     }
-    Ok(())
-}
-
-fn write_csv_field(out: &mut impl Write, field: &str) -> Result<()> {
-    let needs_quotes = field.contains([',', '"', '\n', '\r']);
-    if !needs_quotes {
-        out.write_all(field.as_bytes())?;
-        return Ok(());
-    }
-
-    out.write_all(b"\"")?;
-    for b in field.as_bytes() {
-        if *b == b'"' {
-            out.write_all(b"\"\"")?;
-        } else {
-            out.write_all(&[*b])?;
-        }
-    }
-    out.write_all(b"\"")?;
     Ok(())
 }
 

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -2,8 +2,126 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use rusqlite::{Connection, DatabaseName, OpenFlags};
 
 use crate::error::{HarliteError, Result};
+
+/// Controls whether database-supplied blob paths may be accessed.
+///
+/// Paths are disabled by default. When enabled, both relative and absolute
+/// paths must resolve beneath a canonical root directory.
+#[derive(Clone, Debug)]
+pub struct ExternalPathPolicy {
+    root: Option<PathBuf>,
+}
+
+impl ExternalPathPolicy {
+    pub fn new(
+        database: &Path,
+        allow_external_paths: bool,
+        external_path_root: Option<&Path>,
+    ) -> Result<Self> {
+        if !allow_external_paths {
+            return Ok(Self { root: None });
+        }
+
+        let root = external_path_root
+            .map(Path::to_path_buf)
+            .or_else(|| {
+                database.parent().and_then(|parent| {
+                    (!parent.as_os_str().is_empty()).then(|| parent.to_path_buf())
+                })
+            })
+            .unwrap_or_else(|| PathBuf::from("."));
+        let root = fs::canonicalize(&root).map_err(|err| {
+            HarliteError::InvalidArgs(format!(
+                "External path root could not be resolved ({}): {err}",
+                root.display()
+            ))
+        })?;
+        if !root.is_dir() {
+            return Err(HarliteError::InvalidArgs(format!(
+                "External path root is not a directory: {}",
+                root.display()
+            )));
+        }
+
+        Ok(Self { root: Some(root) })
+    }
+
+    pub fn resolve_file(&self, raw_path: &str) -> Option<PathBuf> {
+        let root = self.root.as_ref()?;
+        let candidate = PathBuf::from(raw_path);
+        let candidate = if candidate.is_absolute() {
+            candidate
+        } else {
+            root.join(candidate)
+        };
+        let resolved = fs::canonicalize(candidate).ok()?;
+        if resolved.starts_with(root) && resolved.is_file() {
+            Some(resolved)
+        } else {
+            None
+        }
+    }
+}
+
+/// Copy a live SQLite database, including committed WAL content, via SQLite's
+/// online backup API rather than a raw filesystem copy.
+pub fn copy_database_consistent(source: &Path, destination: &Path) -> Result<()> {
+    let source_conn = Connection::open_with_flags(source, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    source_conn.backup(DatabaseName::Main, destination, None)?;
+    Ok(())
+}
+
+pub fn remove_database_with_sidecars(database: &Path) -> Result<()> {
+    if database.exists() {
+        fs::remove_file(database)?;
+    }
+    for suffix in ["-wal", "-shm"] {
+        let mut sidecar = database.as_os_str().to_os_string();
+        sidecar.push(suffix);
+        let sidecar = PathBuf::from(sidecar);
+        if sidecar.exists() {
+            fs::remove_file(sidecar)?;
+        }
+    }
+    Ok(())
+}
+
+/// Remove blobs and FTS rows no longer referenced by any entry.
+pub fn delete_orphaned_blobs(conn: &Connection) -> Result<usize> {
+    let has_fts: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='response_body_fts')",
+        [],
+        |row| row.get(0),
+    )?;
+    if has_fts {
+        conn.execute(
+            "DELETE FROM response_body_fts WHERE NOT EXISTS (SELECT 1 FROM entries WHERE response_body_hash = response_body_fts.hash)",
+            [],
+        )?;
+    }
+    Ok(conn.execute(
+        "DELETE FROM blobs WHERE NOT EXISTS (SELECT 1 FROM entries WHERE request_body_hash = blobs.hash OR response_body_hash = blobs.hash OR response_body_hash_raw = blobs.hash)",
+        [],
+    )?)
+}
+
+/// Configure deletion overwrites before sensitive writes and compact the final
+/// database so superseded values are not retained in free pages or WAL files.
+pub fn prepare_sensitive_write(conn: &Connection) -> Result<()> {
+    conn.execute_batch("PRAGMA foreign_keys=ON; PRAGMA secure_delete=ON;")?;
+    Ok(())
+}
+
+pub fn finalize_sensitive_write(conn: &Connection) -> Result<()> {
+    delete_orphaned_blobs(conn)?;
+    conn.execute_batch(
+        "PRAGMA wal_checkpoint(TRUNCATE); VACUUM; PRAGMA wal_checkpoint(TRUNCATE);",
+    )?;
+    Ok(())
+}
 
 pub fn canonicalize_path_for_compare(path: &Path) -> Result<PathBuf> {
     if path.exists() {
@@ -96,7 +214,7 @@ fn resolve_database_in_dir(dir: &Path) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_database_in_dir;
+    use super::{resolve_database_in_dir, ExternalPathPolicy};
     use crate::error::HarliteError;
     use tempfile::TempDir;
 
@@ -135,5 +253,41 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn external_paths_are_disabled_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("blob");
+        std::fs::write(&file, b"secret").unwrap();
+        let policy = ExternalPathPolicy::new(&tmp.path().join("test.db"), false, None).unwrap();
+        assert!(policy.resolve_file(file.to_str().unwrap()).is_none());
+    }
+
+    #[test]
+    fn external_path_default_root_handles_relative_database() {
+        let policy = ExternalPathPolicy::new(std::path::Path::new("test.db"), true, None);
+        assert!(policy.is_ok());
+    }
+
+    #[test]
+    fn external_paths_must_stay_inside_root() {
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let inside_file = root.path().join("blob");
+        let outside_file = outside.path().join("secret");
+        std::fs::write(&inside_file, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+
+        let policy = ExternalPathPolicy::new(
+            &root.path().join("test.db"),
+            true,
+            Some(root.path()),
+        )
+        .unwrap();
+        assert_eq!(policy.resolve_file("blob"), Some(inside_file.canonicalize().unwrap()));
+        assert!(policy
+            .resolve_file(outside_file.to_str().unwrap())
+            .is_none());
     }
 }

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -177,7 +177,7 @@ pub fn remove_database_with_sidecars(database: &Path) -> Result<()> {
 }
 
 fn remove_database_sidecars(database: &Path) -> Result<()> {
-    for suffix in ["-wal", "-shm"] {
+    for suffix in ["-journal", "-wal", "-shm"] {
         let mut sidecar = database.as_os_str().to_os_string();
         sidecar.push(suffix);
         let sidecar = PathBuf::from(sidecar);
@@ -313,7 +313,7 @@ fn resolve_database_in_dir(dir: &Path) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_database_in_dir, ExternalPathPolicy};
+    use super::{remove_database_with_sidecars, resolve_database_in_dir, ExternalPathPolicy};
     use crate::error::HarliteError;
     use tempfile::TempDir;
 
@@ -325,6 +325,23 @@ mod tests {
 
         let resolved = resolve_database_in_dir(tmp.path()).unwrap();
         assert_eq!(resolved, db_path);
+    }
+
+    #[test]
+    fn remove_database_cleans_sqlite_sidecars() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("staged.db");
+        std::fs::write(&db_path, b"database").unwrap();
+        for suffix in ["-journal", "-wal", "-shm"] {
+            std::fs::write(tmp.path().join(format!("staged.db{suffix}")), b"sidecar").unwrap();
+        }
+
+        remove_database_with_sidecars(&db_path).unwrap();
+
+        assert!(!db_path.exists());
+        for suffix in ["-journal", "-wal", "-shm"] {
+            assert!(!tmp.path().join(format!("staged.db{suffix}")).exists());
+        }
     }
 
     #[test]

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -1,5 +1,6 @@
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use rusqlite::{Connection, DatabaseName, OpenFlags};
@@ -74,10 +75,108 @@ pub fn copy_database_consistent(source: &Path, destination: &Path) -> Result<()>
     Ok(())
 }
 
+static NEXT_STAGED_DATABASE_ID: AtomicU64 = AtomicU64::new(0);
+
+/// A consistent database copy staged beside its final destination.
+///
+/// The staged database and its sidecars are removed on error or early return.
+/// Publishing uses a same-directory rename so callers never expose an
+/// unredacted source copy at the requested output path.
+pub struct StagedDatabase {
+    path: PathBuf,
+    destination: PathBuf,
+    overwrite: bool,
+    published: bool,
+}
+
+impl StagedDatabase {
+    pub fn copy_from(source: &Path, destination: &Path, overwrite: bool) -> Result<Self> {
+        let parent = destination
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let file_name = destination
+            .file_name()
+            .ok_or_else(|| HarliteError::InvalidArgs("Output path must be a file".to_string()))?
+            .to_string_lossy();
+
+        let path = loop {
+            let id = NEXT_STAGED_DATABASE_ID.fetch_add(1, Ordering::Relaxed);
+            let candidate = parent.join(format!(
+                ".{file_name}.harlite-stage-{}-{id}",
+                std::process::id()
+            ));
+            match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&candidate)
+            {
+                Ok(file) => {
+                    drop(file);
+                    break candidate;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(err) => return Err(err.into()),
+            }
+        };
+
+        let staged = Self {
+            path,
+            destination: destination.to_path_buf(),
+            overwrite,
+            published: false,
+        };
+        copy_database_consistent(source, &staged.path)?;
+        Ok(staged)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn publish(mut self) -> Result<PathBuf> {
+        if self.destination.exists() && !self.overwrite {
+            return Err(HarliteError::InvalidArgs(format!(
+                "Output database already exists: {} (use --force to overwrite)",
+                self.destination.display()
+            )));
+        }
+
+        remove_database_sidecars(&self.path)?;
+        remove_database_sidecars(&self.destination)?;
+        if let Err(err) = fs::rename(&self.path, &self.destination) {
+            // Windows does not replace an existing file with rename. Preserve
+            // atomic replacement where the platform supports it, then fall
+            // back to remove-and-rename only for an explicit overwrite.
+            if self.overwrite && self.destination.exists() {
+                fs::remove_file(&self.destination)?;
+                fs::rename(&self.path, &self.destination)?;
+            } else {
+                return Err(err.into());
+            }
+        }
+        self.published = true;
+        Ok(self.destination.clone())
+    }
+}
+
+impl Drop for StagedDatabase {
+    fn drop(&mut self) {
+        if !self.published {
+            let _ = remove_database_with_sidecars(&self.path);
+        }
+    }
+}
+
 pub fn remove_database_with_sidecars(database: &Path) -> Result<()> {
     if database.exists() {
         fs::remove_file(database)?;
     }
+    remove_database_sidecars(database)
+}
+
+fn remove_database_sidecars(database: &Path) -> Result<()> {
     for suffix in ["-wal", "-shm"] {
         let mut sidecar = database.as_os_str().to_os_string();
         sidecar.push(suffix);

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -511,6 +511,42 @@ mod tests {
     }
 
     #[test]
+    fn staged_database_restores_existing_files_when_install_fails() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("source.db");
+        let destination = tmp.path().join("destination.db");
+        let conn = rusqlite::Connection::open(&source).unwrap();
+        conn.execute_batch("CREATE TABLE value (number INTEGER);")
+            .unwrap();
+        drop(conn);
+        std::fs::write(&destination, b"previous database").unwrap();
+        for suffix in ["-journal", "-wal", "-shm"] {
+            std::fs::write(
+                tmp.path().join(format!("destination.db{suffix}")),
+                suffix.as_bytes(),
+            )
+            .unwrap();
+        }
+
+        let staged = StagedDatabase::copy_from(&source, &destination, true).unwrap();
+        std::fs::remove_file(staged.path()).unwrap();
+        assert!(staged.publish().is_err());
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"previous database");
+        for suffix in ["-journal", "-wal", "-shm"] {
+            assert_eq!(
+                std::fs::read(tmp.path().join(format!("destination.db{suffix}"))).unwrap(),
+                suffix.as_bytes()
+            );
+        }
+        assert!(!std::fs::read_dir(tmp.path()).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("harlite-backup")));
+    }
+
+    #[test]
     fn resolve_database_in_dir_errors_when_missing() {
         let tmp = TempDir::new().unwrap();
         let err = resolve_database_in_dir(tmp.path()).unwrap_err();

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -89,6 +89,14 @@ pub struct StagedDatabase {
     published: bool,
 }
 
+struct DestinationBackup {
+    destination: PathBuf,
+    directory: PathBuf,
+    moved_main: bool,
+    moved_sidecars: Vec<&'static str>,
+    active: bool,
+}
+
 impl StagedDatabase {
     pub fn copy_from(source: &Path, destination: &Path, overwrite: bool) -> Result<Self> {
         let parent = destination
@@ -136,6 +144,12 @@ impl StagedDatabase {
     }
 
     pub fn publish(mut self) -> Result<PathBuf> {
+        if self.destination.exists() && !self.destination.is_file() {
+            return Err(HarliteError::InvalidArgs(format!(
+                "Output path must be a file: {}",
+                self.destination.display()
+            )));
+        }
         if self.destination.exists() && !self.overwrite {
             return Err(HarliteError::InvalidArgs(format!(
                 "Output database already exists: {} (use --force to overwrite)",
@@ -144,17 +158,21 @@ impl StagedDatabase {
         }
 
         remove_database_sidecars(&self.path)?;
-        remove_database_sidecars(&self.destination)?;
-        if let Err(err) = fs::rename(&self.path, &self.destination) {
-            // Windows does not replace an existing file with rename. Preserve
-            // atomic replacement where the platform supports it, then fall
-            // back to remove-and-rename only for an explicit overwrite.
-            if self.overwrite && self.destination.exists() {
-                fs::remove_file(&self.destination)?;
-                fs::rename(&self.path, &self.destination)?;
-            } else {
-                return Err(err.into());
-            }
+        let has_destination_files = self.destination.exists()
+            || database_sidecar_suffixes()
+                .iter()
+                .any(|suffix| database_sidecar_path(&self.destination, suffix).exists());
+        let backup = if has_destination_files {
+            let mut backup = DestinationBackup::new(&self.destination)?;
+            backup.capture()?;
+            Some(backup)
+        } else {
+            None
+        };
+
+        fs::rename(&self.path, &self.destination)?;
+        if let Some(backup) = backup {
+            backup.discard();
         }
         self.published = true;
         Ok(self.destination.clone())
@@ -169,6 +187,83 @@ impl Drop for StagedDatabase {
     }
 }
 
+impl DestinationBackup {
+    fn new(destination: &Path) -> Result<Self> {
+        let parent = destination
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let file_name = destination
+            .file_name()
+            .ok_or_else(|| HarliteError::InvalidArgs("Output path must be a file".to_string()))?
+            .to_string_lossy();
+        let directory = loop {
+            let id = NEXT_STAGED_DATABASE_ID.fetch_add(1, Ordering::Relaxed);
+            let candidate = parent.join(format!(
+                ".{file_name}.harlite-backup-{}-{id}",
+                std::process::id()
+            ));
+            match fs::create_dir(&candidate) {
+                Ok(()) => break candidate,
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(err) => return Err(err.into()),
+            }
+        };
+
+        Ok(Self {
+            destination: destination.to_path_buf(),
+            directory,
+            moved_main: false,
+            moved_sidecars: Vec::new(),
+            active: true,
+        })
+    }
+
+    fn capture(&mut self) -> Result<()> {
+        if self.destination.exists() {
+            fs::rename(&self.destination, self.directory.join("database"))?;
+            self.moved_main = true;
+        }
+        for suffix in database_sidecar_suffixes() {
+            let source = database_sidecar_path(&self.destination, suffix);
+            if source.exists() {
+                fs::rename(&source, self.directory.join(format!("database{suffix}")))?;
+                self.moved_sidecars.push(suffix);
+            }
+        }
+        Ok(())
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        while let Some(suffix) = self.moved_sidecars.pop() {
+            fs::rename(
+                self.directory.join(format!("database{suffix}")),
+                database_sidecar_path(&self.destination, suffix),
+            )?;
+        }
+        if self.moved_main {
+            fs::rename(self.directory.join("database"), &self.destination)?;
+            self.moved_main = false;
+        }
+        fs::remove_dir(&self.directory)?;
+        self.active = false;
+        Ok(())
+    }
+
+    fn discard(mut self) {
+        self.active = false;
+        let _ = fs::remove_dir_all(&self.directory);
+    }
+}
+
+impl Drop for DestinationBackup {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = self.restore();
+        }
+    }
+}
+
 pub fn remove_database_with_sidecars(database: &Path) -> Result<()> {
     if database.exists() {
         fs::remove_file(database)?;
@@ -177,15 +272,23 @@ pub fn remove_database_with_sidecars(database: &Path) -> Result<()> {
 }
 
 fn remove_database_sidecars(database: &Path) -> Result<()> {
-    for suffix in ["-journal", "-wal", "-shm"] {
-        let mut sidecar = database.as_os_str().to_os_string();
-        sidecar.push(suffix);
-        let sidecar = PathBuf::from(sidecar);
+    for suffix in database_sidecar_suffixes() {
+        let sidecar = database_sidecar_path(database, suffix);
         if sidecar.exists() {
             fs::remove_file(sidecar)?;
         }
     }
     Ok(())
+}
+
+fn database_sidecar_suffixes() -> [&'static str; 3] {
+    ["-journal", "-wal", "-shm"]
+}
+
+fn database_sidecar_path(database: &Path, suffix: &str) -> PathBuf {
+    let mut sidecar = database.as_os_str().to_os_string();
+    sidecar.push(suffix);
+    PathBuf::from(sidecar)
 }
 
 /// Remove blobs and FTS rows no longer referenced by any entry.
@@ -215,7 +318,6 @@ pub fn prepare_sensitive_write(conn: &Connection) -> Result<()> {
 }
 
 pub fn finalize_sensitive_write(conn: &Connection) -> Result<()> {
-    delete_orphaned_blobs(conn)?;
     conn.execute_batch(
         "PRAGMA wal_checkpoint(TRUNCATE); VACUUM; PRAGMA wal_checkpoint(TRUNCATE);",
     )?;
@@ -313,7 +415,10 @@ fn resolve_database_in_dir(dir: &Path) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{remove_database_with_sidecars, resolve_database_in_dir, ExternalPathPolicy};
+    use super::{
+        remove_database_with_sidecars, resolve_database_in_dir, DestinationBackup,
+        ExternalPathPolicy, StagedDatabase,
+    };
     use crate::error::HarliteError;
     use tempfile::TempDir;
 
@@ -342,6 +447,67 @@ mod tests {
         for suffix in ["-journal", "-wal", "-shm"] {
             assert!(!tmp.path().join(format!("staged.db{suffix}")).exists());
         }
+    }
+
+    #[test]
+    fn destination_backup_restores_database_and_sidecars_on_drop() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("existing.db");
+        std::fs::write(&db_path, b"database").unwrap();
+        for suffix in ["-journal", "-wal", "-shm"] {
+            std::fs::write(tmp.path().join(format!("existing.db{suffix}")), suffix).unwrap();
+        }
+
+        {
+            let mut backup = DestinationBackup::new(&db_path).unwrap();
+            backup.capture().unwrap();
+            assert!(!db_path.exists());
+            assert!(!tmp.path().join("existing.db-wal").exists());
+        }
+
+        assert_eq!(std::fs::read(&db_path).unwrap(), b"database");
+        for suffix in ["-journal", "-wal", "-shm"] {
+            assert_eq!(
+                std::fs::read(tmp.path().join(format!("existing.db{suffix}"))).unwrap(),
+                suffix.as_bytes()
+            );
+        }
+    }
+
+    #[test]
+    fn staged_database_replaces_existing_database_and_sidecars() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("source.db");
+        let destination = tmp.path().join("destination.db");
+        let conn = rusqlite::Connection::open(&source).unwrap();
+        conn.execute_batch("CREATE TABLE value (number INTEGER); INSERT INTO value VALUES (42);")
+            .unwrap();
+        drop(conn);
+        std::fs::write(&destination, b"previous database").unwrap();
+        for suffix in ["-journal", "-wal", "-shm"] {
+            std::fs::write(
+                tmp.path().join(format!("destination.db{suffix}")),
+                b"previous sidecar",
+            )
+            .unwrap();
+        }
+
+        let staged = StagedDatabase::copy_from(&source, &destination, true).unwrap();
+        staged.publish().unwrap();
+
+        let conn = rusqlite::Connection::open(&destination).unwrap();
+        let value: i64 = conn
+            .query_row("SELECT number FROM value", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, 42);
+        for suffix in ["-journal", "-wal", "-shm"] {
+            assert!(!tmp.path().join(format!("destination.db{suffix}")).exists());
+        }
+        assert!(!std::fs::read_dir(tmp.path()).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("harlite-backup")));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,11 @@ pub enum HarliteError {
     #[error("Database error: {0}")]
     Database(#[from] rusqlite::Error),
 
+    /// Parquet encoding error (only available with the parquet feature).
+    #[cfg(feature = "parquet")]
+    #[error("Parquet error: {0}")]
+    Parquet(#[from] parquet::errors::ParquetError),
+
     /// Validation error for HAR data missing required fields.
     #[error("Invalid HAR file: {0}")]
     InvalidHar(String),

--- a/src/har/parser.rs
+++ b/src/har/parser.rs
@@ -14,6 +14,9 @@ use crate::error::HarliteError;
 
 pub type Extensions = serde_json::Map<String, serde_json::Value>;
 
+/// Maximum decompressed JSON bytes accepted by the default HAR parsers.
+pub const DEFAULT_MAX_HAR_INPUT_BYTES: usize = 512 * 1024 * 1024;
+
 fn extensions_is_empty(ext: &Extensions) -> bool {
     ext.is_empty()
 }
@@ -186,6 +189,11 @@ pub struct Timings {
 
 /// Parse a HAR file from disk into strongly typed structures.
 pub fn parse_har_file(path: &Path) -> Result<Har> {
+    parse_har_file_with_limit(path, DEFAULT_MAX_HAR_INPUT_BYTES)
+}
+
+/// Parse a HAR with an explicit limit on decompressed JSON bytes.
+pub fn parse_har_file_with_limit(path: &Path, max_input_bytes: usize) -> Result<Har> {
     let mut file = File::open(path)?;
     let mut prefix = [0u8; 4];
     let prefix_len = file.read(&mut prefix)?;
@@ -220,7 +228,7 @@ pub fn parse_har_file(path: &Path) -> Result<Har> {
         Compression::None => Box::new(chained),
     };
 
-    let reader = BufReader::new(reader);
+    let reader = BufReader::new(LimitedReader::new(reader, max_input_bytes));
     let mut deserializer = serde_json::Deserializer::from_reader(reader);
     let har = Har::deserialize(&mut deserializer)?;
     deserializer.end()?;
@@ -229,6 +237,11 @@ pub fn parse_har_file(path: &Path) -> Result<Har> {
 
 /// Parse a HAR file using a background reader thread (async I/O).
 pub fn parse_har_file_async(path: &Path) -> Result<Har> {
+    parse_har_file_async_with_limit(path, DEFAULT_MAX_HAR_INPUT_BYTES)
+}
+
+/// Parse a HAR using a background reader with an explicit decompressed limit.
+pub fn parse_har_file_async_with_limit(path: &Path, max_input_bytes: usize) -> Result<Har> {
     let mut file = File::open(path)?;
     let mut prefix = [0u8; 4];
     let prefix_len = file.read(&mut prefix)?;
@@ -267,7 +280,7 @@ pub fn parse_har_file_async(path: &Path) -> Result<Har> {
         Compression::None => Box::new(AsyncFileReader::new(file, prefix_vec)),
     };
 
-    let reader = BufReader::new(reader);
+    let reader = BufReader::new(LimitedReader::new(reader, max_input_bytes));
     let mut deserializer = serde_json::Deserializer::from_reader(reader);
     let har = Har::deserialize(&mut deserializer)?;
     deserializer.end()?;
@@ -275,6 +288,49 @@ pub fn parse_har_file_async(path: &Path) -> Result<Har> {
 }
 
 const ASYNC_READ_CHUNK_BYTES: usize = 128 * 1024;
+
+struct LimitedReader<R> {
+    inner: R,
+    bytes_read: usize,
+    limit: usize,
+}
+
+impl<R> LimitedReader<R> {
+    fn new(inner: R, limit: usize) -> Self {
+        Self {
+            inner,
+            bytes_read: 0,
+            limit,
+        }
+    }
+}
+
+impl<R: Read> Read for LimitedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.bytes_read == self.limit {
+            let mut probe = [0u8; 1];
+            return match self.inner.read(&mut probe)? {
+                0 => Ok(0),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "decompressed HAR input exceeds the {} byte limit",
+                        self.limit
+                    ),
+                )),
+            };
+        }
+
+        let remaining = self.limit - self.bytes_read;
+        let max_read = remaining.min(buf.len());
+        let read = self.inner.read(&mut buf[..max_read])?;
+        self.bytes_read += read;
+        Ok(read)
+    }
+}
 
 struct AsyncFileReader {
     prefix: Cursor<Vec<u8>>,
@@ -285,7 +341,9 @@ struct AsyncFileReader {
 
 impl AsyncFileReader {
     fn new(file: File, prefix: Vec<u8>) -> Self {
-        let (tx, rx) = mpsc::channel();
+        // Bound read-ahead so async parsing cannot queue an entire hostile
+        // input file in memory while decompression/deserialization is slower.
+        let (tx, rx) = mpsc::sync_channel(4);
         thread::spawn(move || {
             let mut file = file;
             let mut buf = vec![0u8; ASYNC_READ_CHUNK_BYTES];
@@ -543,7 +601,7 @@ impl<'de> Visitor<'de> for EntriesVisitor {
 
 #[cfg(test)]
 mod tests {
-    use super::{detect_compression, Compression, Har};
+    use super::{detect_compression, parse_har_file_with_limit, Compression, Har};
     use std::path::Path;
 
     #[test]
@@ -702,5 +760,14 @@ mod tests {
             detect_compression(Path::new("trace.har.br"), &[0u8, 0u8, 0u8, 0u8]),
             Compression::Brotli
         );
+    }
+
+    #[test]
+    fn rejects_decompressed_input_over_limit() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), br#"{"log":{"entries":[]}}"#).unwrap();
+
+        let err = parse_har_file_with_limit(temp.path(), 8).unwrap_err();
+        assert!(err.to_string().contains("exceeds the 8 byte limit"));
     }
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -215,13 +215,12 @@ pub fn resolve_plugins(
     let disabled_set: HashSet<&str> = disabled.iter().map(|s| s.as_str()).collect();
     let mut resolved = Vec::new();
     for plugin in configs {
-        let mut is_enabled = plugin.enabled.unwrap_or(true);
-        if disabled_set.contains(plugin.name.as_str()) {
-            is_enabled = false;
-        }
-        if enabled_set.contains(plugin.name.as_str()) {
-            is_enabled = true;
-        }
+        // Plugin commands may come from project-local configuration. Requiring
+        // an explicit CLI enable prevents merely entering a directory from
+        // authorizing arbitrary command execution.
+        let is_enabled = enabled_set.contains(plugin.name.as_str())
+            && plugin.enabled != Some(false)
+            && !disabled_set.contains(plugin.name.as_str());
         if is_enabled {
             resolved.push(plugin.clone());
         }
@@ -342,4 +341,40 @@ fn run_plugin<T: Serialize, R: for<'de> Deserialize<'de>>(
             plugin.name, err
         ))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_plugins, PluginConfig, PluginKind};
+
+    fn config(enabled: Option<bool>) -> PluginConfig {
+        PluginConfig {
+            name: "test".to_string(),
+            kind: PluginKind::Filter,
+            command: "ignored".to_string(),
+            args: Vec::new(),
+            enabled,
+            phase: None,
+        }
+    }
+
+    #[test]
+    fn config_never_enables_command_execution_implicitly() {
+        assert!(resolve_plugins(&[config(None)], &[], &[])
+            .unwrap()
+            .is_empty());
+        assert!(resolve_plugins(&[config(Some(true))], &[], &[])
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn explicit_cli_enable_is_required_and_config_can_disable() {
+        assert!(!resolve_plugins(&[config(None)], &["test".to_string()], &[])
+            .unwrap()
+            .is_empty());
+        assert!(resolve_plugins(&[config(Some(false))], &["test".to_string()], &[])
+            .unwrap()
+            .is_empty());
+    }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,10 +4,12 @@ use clap::CommandFactory;
 use crate::cli::{Cli, Commands};
 use crate::commands::{
     run_analyze, run_diff, run_export, run_export_data, run_fts_rebuild, run_import, run_imports,
-    run_info, run_merge, run_openapi, run_pii, run_prune, run_query, run_redact, run_report,
+    run_info, run_merge, run_openapi, run_pii, run_pii_with_external_paths, run_prune,
+    run_prune_with_options, run_query, run_redact, run_redact_with_external_paths,
+    run_report,
     run_schema, run_search, run_stats, run_waterfall, AnalyzeOptions, DiffOptions,
     EntryFilterOptions, ExportDataOptions, ExportOptions, ImportOptions, InfoOptions, MergeOptions,
-    OpenApiOptions, PiiOptions, QueryOptions, RedactOptions, ReportOptions, StatsOptions,
+    OpenApiOptions, PiiOptions, PruneOptions, QueryOptions, RedactOptions, ReportOptions, StatsOptions,
     WaterfallFormat, WaterfallGroupBy, WaterfallOptions,
 };
 #[cfg(feature = "cdp")]
@@ -240,7 +242,22 @@ pub fn run(cli: Cli) -> Result<()> {
         Commands::Prune {
             database,
             import_id,
-        } => run_prune(database, import_id),
+            allow_external_paths,
+            external_path_root,
+        } => {
+            if allow_external_paths {
+                run_prune_with_options(
+                    database,
+                    import_id,
+                    &PruneOptions {
+                        allow_external_paths,
+                        external_path_root,
+                    },
+                )
+            } else {
+                run_prune(database, import_id)
+            }
+        }
 
         Commands::Stats {
             database,
@@ -607,6 +624,8 @@ pub fn run(cli: Cli) -> Result<()> {
             body_regex,
             match_mode,
             token,
+            allow_external_paths,
+            external_path_root,
             database,
         } => {
             let defaults = &resolved.redact;
@@ -622,7 +641,16 @@ pub fn run(cli: Cli) -> Result<()> {
                 match_mode: match_mode.unwrap_or(defaults.match_mode),
                 token: token.unwrap_or_else(|| defaults.token.clone()),
             };
-            run_redact(database, &options)
+            if allow_external_paths {
+                run_redact_with_external_paths(
+                    database,
+                    &options,
+                    allow_external_paths,
+                    external_path_root.as_deref(),
+                )
+            } else {
+                run_redact(database, &options)
+            }
         }
 
         Commands::Pii {
@@ -641,6 +669,8 @@ pub fn run(cli: Cli) -> Result<()> {
             ssn_regex,
             credit_card_regex,
             token,
+            allow_external_paths,
+            external_path_root,
             database,
         } => {
             let defaults = &resolved.pii;
@@ -662,7 +692,16 @@ pub fn run(cli: Cli) -> Result<()> {
                     .unwrap_or_else(|| defaults.credit_card_regex.clone()),
                 token: token.unwrap_or_else(|| defaults.token.clone()),
             };
-            run_pii(database, &options)
+            if allow_external_paths {
+                run_pii_with_external_paths(
+                    database,
+                    &options,
+                    allow_external_paths,
+                    external_path_root.as_deref(),
+                )
+            } else {
+                run_pii(database, &options)
+            }
         }
 
         Commands::Diff {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1873,6 +1873,115 @@ fn test_pii_redaction_rolls_back_every_entry_on_failure() {
 }
 
 #[test]
+fn test_pii_redaction_rolls_back_when_orphan_cleanup_fails() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("source.db");
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let original_hash: String = conn
+        .query_row(
+            "SELECT response_body_hash FROM entries ORDER BY id LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    conn.execute(
+        "UPDATE blobs SET content=?1, size=?2 WHERE hash=?3",
+        rusqlite::params![
+            b"cleanup@example.com".as_slice(),
+            "cleanup@example.com".len() as i64,
+            original_hash.as_str()
+        ],
+    )
+    .unwrap();
+    let blobs_before: i64 = conn
+        .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+        .unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER fail_pii_blob_cleanup BEFORE DELETE ON blobs BEGIN SELECT RAISE(ABORT, 'cleanup blocked'); END;",
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args(["pii", "--redact", "--format", "json"])
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cleanup blocked"));
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let hash_after: String = conn
+        .query_row(
+            "SELECT response_body_hash FROM entries ORDER BY id LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let blobs_after: i64 = conn
+        .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(hash_after, original_hash);
+    assert_eq!(blobs_after, blobs_before);
+}
+
+#[test]
+fn test_redact_rolls_back_when_orphan_cleanup_fails() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("source.db");
+
+    harlite()
+        .args(["import", "tests/fixtures/redact.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let original: (String, String) = conn
+        .query_row(
+            "SELECT request_headers, response_body_hash FROM entries LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    let blobs_before: i64 = conn
+        .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+        .unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER fail_redact_blob_cleanup BEFORE DELETE ON blobs BEGIN SELECT RAISE(ABORT, 'cleanup blocked'); END;",
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args(["redact", "--body-regex", "ok"])
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cleanup blocked"));
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let after: (String, String) = conn
+        .query_row(
+            "SELECT request_headers, response_body_hash FROM entries LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    let blobs_after: i64 = conn
+        .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(after, original);
+    assert_eq!(blobs_after, blobs_before);
+}
+
+#[test]
 fn test_redact_failures_do_not_publish_output_database() {
     let tmp = TempDir::new().unwrap();
     let db_path = tmp.path().join("source.db");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -352,6 +352,83 @@ fn test_prune_preserves_external_file_referenced_by_surviving_blob() {
     assert_eq!(surviving_refs, 1);
 }
 
+#[test]
+fn test_prune_rolls_back_on_malformed_surviving_external_path() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let bodies_dir = tmp.path().join("bodies");
+    let shared_path = bodies_dir.join("shared-body");
+    fs::create_dir(&bodies_dir).unwrap();
+    fs::write(&shared_path, b"shared").unwrap();
+
+    for _ in 0..2 {
+        harlite()
+            .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+            .arg(&db_path)
+            .assert()
+            .success();
+    }
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_ids: Vec<i64> = conn
+        .prepare("SELECT id FROM imports ORDER BY id")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect();
+    let shared = shared_path.to_string_lossy();
+    conn.execute(
+        "INSERT INTO blobs(hash, content, size, mime_type, external_path) VALUES('orphan', X'', 6, 'text/plain', ?1)",
+        [shared.as_ref()],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO blobs(hash, content, size, mime_type, external_path) VALUES('keeper', X'', 6, 'text/plain', CAST(?1 AS BLOB))",
+        [shared.as_ref()],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE entries SET request_body_hash='orphan', request_body_size=6 WHERE id=(SELECT MIN(id) FROM entries WHERE import_id=?1)",
+        [import_ids[0]],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE entries SET request_body_hash='keeper', request_body_size=6 WHERE id=(SELECT MIN(id) FROM entries WHERE import_id=?1)",
+        [import_ids[1]],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args([
+            "prune",
+            "--import-id",
+            &import_ids[0].to_string(),
+            "--allow-external-paths",
+            "--external-path-root",
+        ])
+        .arg(&bodies_dir)
+        .arg(&db_path)
+        .assert()
+        .failure();
+
+    assert!(shared_path.exists());
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM imports", [], |row| row.get(0))
+        .unwrap();
+    let orphan_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM blobs WHERE hash='orphan'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(import_count, 2);
+    assert_eq!(orphan_count, 1);
+}
+
 #[cfg(unix)]
 #[test]
 fn test_project_config_cannot_implicitly_execute_plugin() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -429,6 +429,111 @@ fn test_prune_rolls_back_on_malformed_surviving_external_path() {
     assert_eq!(orphan_count, 1);
 }
 
+#[test]
+fn test_prune_rolls_back_on_malformed_pruned_external_path() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let bodies_dir = tmp.path().join("bodies");
+    let external_path = bodies_dir.join("external-body");
+    fs::create_dir(&bodies_dir).unwrap();
+    fs::write(&external_path, b"external").unwrap();
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_id: i64 = conn
+        .query_row("SELECT id FROM imports LIMIT 1", [], |row| row.get(0))
+        .unwrap();
+    let external = external_path.to_string_lossy();
+    conn.execute(
+        "INSERT INTO blobs(hash, content, size, mime_type, external_path) VALUES('malformed-path', X'', 8, 'text/plain', CAST(?1 AS BLOB))",
+        [external.as_ref()],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE entries SET request_body_hash='malformed-path', request_body_size=8 WHERE id=(SELECT MIN(id) FROM entries)",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args([
+            "prune",
+            "--import-id",
+            &import_id.to_string(),
+            "--allow-external-paths",
+            "--external-path-root",
+        ])
+        .arg(&bodies_dir)
+        .arg(&db_path)
+        .assert()
+        .failure();
+
+    assert!(external_path.exists());
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM imports", [], |row| row.get(0))
+        .unwrap();
+    let blob_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM blobs WHERE hash='malformed-path'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(import_count, 1);
+    assert_eq!(blob_count, 1);
+}
+
+#[test]
+fn test_prune_rolls_back_on_malformed_entry_hash() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_id: i64 = conn
+        .query_row("SELECT id FROM imports LIMIT 1", [], |row| row.get(0))
+        .unwrap();
+    conn.execute(
+        "INSERT INTO blobs(hash, content, size, mime_type) VALUES(CAST('malformed-hash' AS BLOB), X'', 0, 'text/plain')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE entries SET request_body_hash=CAST('malformed-hash' AS BLOB) WHERE id=(SELECT MIN(id) FROM entries)",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args(["prune", "--import-id", &import_id.to_string()])
+        .arg(&db_path)
+        .assert()
+        .failure();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM imports", [], |row| row.get(0))
+        .unwrap();
+    let entry_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM entries", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(import_count, 1);
+    assert_eq!(entry_count, 2);
+}
+
 #[cfg(unix)]
 #[test]
 fn test_project_config_cannot_implicitly_execute_plugin() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -174,6 +174,60 @@ fn test_imports_list_and_prune() {
 }
 
 #[test]
+fn test_prune_does_not_delete_untrusted_external_path_by_default() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let protected_path = tmp.path().join("must-survive.txt");
+    fs::write(&protected_path, b"protected").unwrap();
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_id: i64 = conn
+        .query_row("SELECT id FROM imports LIMIT 1", [], |row| row.get(0))
+        .unwrap();
+    conn.execute(
+        "UPDATE blobs SET external_path=?1 WHERE hash=(SELECT hash FROM blobs LIMIT 1)",
+        [protected_path.to_string_lossy().as_ref()],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args(["prune", "--import-id", &import_id.to_string()])
+        .arg(&db_path)
+        .assert()
+        .success();
+    assert!(protected_path.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn test_project_config_cannot_implicitly_execute_plugin() {
+    let tmp = TempDir::new().unwrap();
+    let marker = tmp.path().join("plugin-ran");
+    let config = format!(
+        "[[plugins]]\nname='untrusted'\nkind='filter'\ncommand='/usr/bin/touch'\nargs=['{}']\nenabled=true\n",
+        marker.display()
+    );
+    fs::write(tmp.path().join("harlite.toml"), config).unwrap();
+    let har_path = fs::canonicalize("tests/fixtures/simple.har").unwrap();
+
+    harlite()
+        .current_dir(tmp.path())
+        .arg("import")
+        .arg(har_path)
+        .args(["-o", "test.db"])
+        .assert()
+        .success();
+    assert!(!marker.exists());
+}
+
+#[test]
 fn test_import_with_pages() {
     let tmp = TempDir::new().unwrap();
     let db_path = tmp.path().join("test.db");
@@ -228,6 +282,30 @@ fn test_export_data_jsonl() {
     let first_line = contents.lines().next().unwrap_or("");
     let parsed: serde_json::Value = serde_json::from_str(first_line).unwrap();
     assert!(parsed.get("url").is_some());
+}
+
+#[cfg(feature = "parquet")]
+#[test]
+fn test_export_data_parquet() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let out_path = tmp.path().join("entries.parquet");
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+    harlite()
+        .args(["export-data", "--format", "parquet", "-o"])
+        .arg(&out_path)
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let bytes = fs::read(&out_path).unwrap();
+    assert!(bytes.starts_with(b"PAR1"));
+    assert!(bytes.ends_with(b"PAR1"));
 }
 
 #[test]
@@ -1325,6 +1403,179 @@ fn test_redact_output_database_keeps_input_unchanged() {
         )
         .unwrap();
     assert_eq!(accept, "application/json");
+}
+
+#[test]
+fn test_redact_output_physically_removes_superseded_secrets() {
+    let tmp = TempDir::new().unwrap();
+    let har_path = tmp.path().join("sensitive.har");
+    let db_path = tmp.path().join("source.db");
+    let out_path = tmp.path().join("redacted.db");
+    let header_secret = format!("Bearer {}", "UNIQUE_HEADER_SECRET_".repeat(256));
+    let body_secret = "UNIQUE_BODY_SECRET_".repeat(256);
+    let har = json!({
+        "log": {
+            "version": "1.2",
+            "creator": { "name": "test", "version": "1" },
+            "entries": [{
+                "startedDateTime": "2024-01-01T00:00:00.000Z",
+                "time": 1,
+                "request": {
+                    "method": "POST",
+                    "url": "https://example.test/submit",
+                    "httpVersion": "HTTP/1.1",
+                    "headers": [{ "name": "Authorization", "value": header_secret }],
+                    "cookies": [],
+                    "queryString": [],
+                    "postData": { "mimeType": "text/plain", "text": body_secret },
+                    "headersSize": -1,
+                    "bodySize": -1
+                },
+                "response": {
+                    "status": 200,
+                    "statusText": "OK",
+                    "httpVersion": "HTTP/1.1",
+                    "headers": [],
+                    "cookies": [],
+                    "content": { "size": 0, "mimeType": "text/plain", "text": "" },
+                    "redirectURL": "",
+                    "headersSize": -1,
+                    "bodySize": 0
+                },
+                "cache": {},
+                "timings": { "send": 0, "wait": 1, "receive": 0 }
+            }]
+        }
+    });
+    fs::write(&har_path, serde_json::to_vec(&har).unwrap()).unwrap();
+
+    harlite()
+        .args(["import", "--bodies", "-o"])
+        .arg(&db_path)
+        .arg(&har_path)
+        .assert()
+        .success();
+    harlite()
+        .args(["redact", "--body-regex", "UNIQUE_BODY_SECRET_", "--output"])
+        .arg(&out_path)
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&out_path).unwrap();
+    let old_blob_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM blobs WHERE CAST(content AS TEXT) LIKE '%UNIQUE_BODY_SECRET_%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(old_blob_count, 0);
+    drop(conn);
+
+    let raw = fs::read(&out_path).unwrap();
+    assert!(!raw
+        .windows(b"UNIQUE_HEADER_SECRET_".len())
+        .any(|window| window == b"UNIQUE_HEADER_SECRET_"));
+    assert!(!raw
+        .windows(b"UNIQUE_BODY_SECRET_".len())
+        .any(|window| window == b"UNIQUE_BODY_SECRET_"));
+}
+
+#[test]
+fn test_redact_ignores_untrusted_external_blob_paths() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("source.db");
+    let out_path = tmp.path().join("redacted.db");
+    let protected_path = tmp.path().join("private.txt");
+    fs::write(&protected_path, b"UNTRUSTED_EXTERNAL_SECRET").unwrap();
+
+    harlite()
+        .args(["import", "tests/fixtures/redact.har", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "INSERT INTO blobs(hash, content, size, mime_type, external_path) VALUES('attacker', X'', 25, 'text/plain', ?1)",
+        [protected_path.to_string_lossy().as_ref()],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE entries SET request_body_hash='attacker', request_body_size=25 WHERE id=(SELECT id FROM entries LIMIT 1)",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args([
+            "redact",
+            "--no-defaults",
+            "--body-regex",
+            "UNTRUSTED_EXTERNAL_SECRET",
+            "--output",
+        ])
+        .arg(&out_path)
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&out_path).unwrap();
+    let hash: String = conn
+        .query_row("SELECT request_body_hash FROM entries LIMIT 1", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let content: Vec<u8> = conn
+        .query_row("SELECT content FROM blobs WHERE hash='attacker'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(hash, "attacker");
+    assert!(content.is_empty());
+}
+
+#[test]
+fn test_pii_redaction_physically_removes_superseded_body() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("source.db");
+    let out_path = tmp.path().join("redacted.db");
+    let secret = "physical-secret@example.com";
+
+    harlite()
+        .args(["import", "tests/fixtures/redact.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE blobs SET content=?1, size=?2 WHERE hash=(SELECT response_body_hash FROM entries LIMIT 1)",
+        rusqlite::params![secret.as_bytes(), secret.len() as i64],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args(["pii", "--redact", "--format", "json", "--output"])
+        .arg(&out_path)
+        .arg(&db_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("email"));
+
+    let conn = rusqlite::Connection::open(&out_path).unwrap();
+    let old_blob_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM blobs WHERE CAST(content AS TEXT) LIKE '%physical-secret@example.com%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(old_blob_count, 0);
+    drop(conn);
+    let raw = fs::read(&out_path).unwrap();
+    assert!(!raw.windows(secret.len()).any(|window| window == secret.as_bytes()));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -146,6 +146,14 @@ fn test_imports_list_and_prune() {
     let import_id: i64 = conn
         .query_row("SELECT id FROM imports LIMIT 1", [], |r| r.get(0))
         .unwrap();
+    let graphql_fields_inserted = conn
+        .execute(
+            "INSERT INTO graphql_fields (entry_id, field) SELECT id, 'viewer' FROM entries WHERE import_id = ?1 LIMIT 1",
+            [import_id],
+        )
+        .unwrap();
+    assert_eq!(graphql_fields_inserted, 1);
+    drop(conn);
 
     harlite()
         .args(["prune", "--import-id", &import_id.to_string()])
@@ -166,11 +174,15 @@ fn test_imports_list_and_prune() {
     let blob_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM blobs", [], |r| r.get(0))
         .unwrap();
+    let graphql_field_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM graphql_fields", [], |r| r.get(0))
+        .unwrap();
 
     assert_eq!(entry_count, 0);
     assert_eq!(import_count, 0);
     assert_eq!(page_count, 0);
     assert_eq!(blob_count, 0);
+    assert_eq!(graphql_field_count, 0);
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -217,6 +217,141 @@ fn test_prune_does_not_delete_untrusted_external_path_by_default() {
     assert!(protected_path.exists());
 }
 
+#[test]
+fn test_prune_external_file_deletion_waits_for_commit() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let bodies_dir = tmp.path().join("bodies");
+
+    harlite()
+        .args([
+            "import",
+            "tests/fixtures/simple.har",
+            "--bodies",
+            "--extract-bodies",
+        ])
+        .arg(&bodies_dir)
+        .args(["-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_id: i64 = conn
+        .query_row("SELECT id FROM imports LIMIT 1", [], |row| row.get(0))
+        .unwrap();
+    let external_paths: Vec<String> = conn
+        .prepare("SELECT external_path FROM blobs WHERE external_path IS NOT NULL")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect();
+    assert!(!external_paths.is_empty());
+    conn.execute_batch(
+        "CREATE TRIGGER fail_blob_delete BEFORE DELETE ON blobs BEGIN SELECT RAISE(ABORT, 'blocked'); END;",
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args([
+            "prune",
+            "--import-id",
+            &import_id.to_string(),
+            "--allow-external-paths",
+            "--external-path-root",
+        ])
+        .arg(&bodies_dir)
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("blocked"));
+
+    assert!(external_paths
+        .iter()
+        .all(|path| std::path::Path::new(path).exists()));
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let entries: i64 = conn
+        .query_row("SELECT COUNT(*) FROM entries", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(entries, 2);
+}
+
+#[test]
+fn test_prune_preserves_external_file_referenced_by_surviving_blob() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let bodies_dir = tmp.path().join("bodies");
+    let shared_path = bodies_dir.join("shared-body");
+    fs::create_dir(&bodies_dir).unwrap();
+    fs::write(&shared_path, b"shared").unwrap();
+
+    for _ in 0..2 {
+        harlite()
+            .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+            .arg(&db_path)
+            .assert()
+            .success();
+    }
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let import_ids: Vec<i64> = conn
+        .prepare("SELECT id FROM imports ORDER BY id")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect();
+    assert_eq!(import_ids.len(), 2);
+    let shared = shared_path.to_string_lossy();
+    conn.execute(
+        "INSERT INTO blobs(hash, content, size, mime_type, external_path) VALUES('orphan', X'', 6, 'text/plain', ?1)",
+        [shared.as_ref()],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO blobs(hash, content, size, mime_type, external_path) VALUES('keeper', X'', 6, 'text/plain', ?1)",
+        [shared.as_ref()],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE entries SET request_body_hash='orphan', request_body_size=6 WHERE id=(SELECT MIN(id) FROM entries WHERE import_id=?1)",
+        [import_ids[0]],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE entries SET request_body_hash='keeper', request_body_size=6 WHERE id=(SELECT MIN(id) FROM entries WHERE import_id=?1)",
+        [import_ids[1]],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args([
+            "prune",
+            "--import-id",
+            &import_ids[0].to_string(),
+            "--allow-external-paths",
+            "--external-path-root",
+        ])
+        .arg(&bodies_dir)
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    assert!(shared_path.exists());
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let surviving_refs: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM entries WHERE request_body_hash='keeper'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(surviving_refs, 1);
+}
+
 #[cfg(unix)]
 #[test]
 fn test_project_config_cannot_implicitly_execute_plugin() {
@@ -1554,6 +1689,7 @@ fn test_pii_redaction_physically_removes_superseded_body() {
     let db_path = tmp.path().join("source.db");
     let out_path = tmp.path().join("redacted.db");
     let secret = "physical-secret@example.com";
+    fs::write(&out_path, b"previous output").unwrap();
 
     harlite()
         .args(["import", "tests/fixtures/redact.har", "--bodies", "-o"])
@@ -1569,7 +1705,7 @@ fn test_pii_redaction_physically_removes_superseded_body() {
     drop(conn);
 
     harlite()
-        .args(["pii", "--redact", "--format", "json", "--output"])
+        .args(["pii", "--redact", "--format", "json", "--force", "--output"])
         .arg(&out_path)
         .arg(&db_path)
         .assert()
@@ -1588,6 +1724,164 @@ fn test_pii_redaction_physically_removes_superseded_body() {
     drop(conn);
     let raw = fs::read(&out_path).unwrap();
     assert!(!raw.windows(secret.len()).any(|window| window == secret.as_bytes()));
+}
+
+#[test]
+fn test_pii_redaction_rolls_back_every_entry_on_failure() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("source.db");
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let original_hashes: Vec<String> = conn
+        .prepare("SELECT response_body_hash FROM entries ORDER BY id")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect();
+    assert_eq!(original_hashes.len(), 2);
+    conn.execute(
+        "UPDATE blobs SET content=?1, size=?2 WHERE hash=?3",
+        rusqlite::params![
+            b"first@example.com".as_slice(),
+            "first@example.com".len() as i64,
+            original_hashes[0]
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE blobs SET content=?1, size=?2 WHERE hash=?3",
+        rusqlite::params![
+            b"second@example.com".as_slice(),
+            "second@example.com".len() as i64,
+            original_hashes[1]
+        ],
+    )
+    .unwrap();
+    let blobs_before: i64 = conn
+        .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+        .unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER fail_second_pii_update BEFORE UPDATE ON entries WHEN OLD.id=2 BEGIN SELECT RAISE(ABORT, 'blocked'); END;",
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .args(["pii", "--redact", "--format", "json"])
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("blocked"));
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let hashes_after: Vec<String> = conn
+        .prepare("SELECT response_body_hash FROM entries ORDER BY id")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect();
+    let blobs_after: i64 = conn
+        .query_row("SELECT COUNT(*) FROM blobs", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(hashes_after, original_hashes);
+    assert_eq!(blobs_after, blobs_before);
+}
+
+#[test]
+fn test_redact_failures_do_not_publish_output_database() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("source.db");
+    let invalid_output = tmp.path().join("invalid-pattern.db");
+    let runtime_output = tmp.path().join("runtime-failure.db");
+    let previous_output = b"previous output";
+
+    harlite()
+        .args(["import", "tests/fixtures/redact.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    fs::write(&invalid_output, previous_output).unwrap();
+    harlite()
+        .args(["redact", "--body-regex", "[", "--force", "--output"])
+        .arg(&invalid_output)
+        .arg(&db_path)
+        .assert()
+        .failure();
+    assert_eq!(fs::read(&invalid_output).unwrap(), previous_output);
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER fail_redact_update BEFORE UPDATE ON entries BEGIN SELECT RAISE(ABORT, 'blocked'); END;",
+    )
+    .unwrap();
+    drop(conn);
+    fs::write(&runtime_output, previous_output).unwrap();
+    harlite()
+        .args(["redact", "--force", "--output"])
+        .arg(&runtime_output)
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("blocked"));
+    assert_eq!(fs::read(&runtime_output).unwrap(), previous_output);
+    assert!(!fs::read_dir(tmp.path()).unwrap().any(|entry| {
+        entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("harlite-stage")
+    }));
+}
+
+#[test]
+fn test_pii_failure_does_not_publish_output_database() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("source.db");
+    let out_path = tmp.path().join("redacted.db");
+    let previous_output = b"previous output";
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE blobs SET content=?1, size=?2 WHERE hash=(SELECT response_body_hash FROM entries ORDER BY id LIMIT 1)",
+        rusqlite::params![b"secret@example.com".as_slice(), "secret@example.com".len() as i64],
+    )
+    .unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER fail_pii_update BEFORE UPDATE ON entries BEGIN SELECT RAISE(ABORT, 'blocked'); END;",
+    )
+    .unwrap();
+    drop(conn);
+    fs::write(&out_path, previous_output).unwrap();
+
+    harlite()
+        .args(["pii", "--redact", "--format", "json", "--force", "--output"])
+        .arg(&out_path)
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("blocked"));
+    assert_eq!(fs::read(&out_path).unwrap(), previous_output);
+    assert!(!fs::read_dir(tmp.path()).unwrap().any(|entry| {
+        entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("harlite-stage")
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Fix seven security findings involving external blob paths, sensitive-data remnants, plugin execution, vulnerable dependencies, replay redirects, compressed HAR expansion, and CSV formula injection.

## Changes
- Deny external blob reads and deletions by default, with canonical root confinement when explicitly enabled.
- Copy SQLite databases through the online backup API and securely remove orphaned blobs, free-page data, and WAL remnants after redaction or PII rewriting.
- Require explicit `--plugin` authorization for configured executables and disable automatic replay redirects.
- Cap decompressed HAR input at 512 MiB, bound asynchronous read-ahead, and neutralize formula-leading CSV fields.
- Upgrade vulnerable Rust dependencies, adapt Parquet export to the current writer API, and add all-feature CI plus dependency auditing.
- Add exploit-focused regression tests and update CLI documentation.

## Testing
- `cargo test --all-features --locked` passed: 60 library tests, 60 binary tests, and 76 integration tests.
- `cargo audit` reported zero known vulnerabilities; three informational unmaintained-package warnings remain.
- `cargo clippy --all-features --all-targets --locked` completed successfully with existing non-blocking warnings.
- `git diff --check` passed.

## Notes
- Configured plugins now require `--plugin <name>` on every run.
- Replay no longer follows redirects automatically.
- External bodies require `--allow-external-paths` and can be confined with `--external-path-root`.
