### PR TITLE
Release harlite 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,32 +2,86 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  test:
+  quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install stable Rust
         run: |
           rustup update stable
           rustup default stable
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Lint all targets and features
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings
       - name: Test all features
         run: cargo test --all-features --locked
+      - name: Check minimal build
+        run: cargo check --all-targets --no-default-features --locked
+      - name: Test minimal library
+        run: cargo test --lib --no-default-features --locked
+      - name: Verify publishable package
+        run: cargo package --locked
+
+  platform-check:
+    name: Platform check (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+          - name: macOS ARM64
+            os: macos-15
+          - name: macOS AMD64
+            os: macos-15-intel
+          - name: Windows AMD64
+            os: windows-2025
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install stable Rust
+        shell: bash
+        run: |
+          rustup update stable
+          rustup default stable
+      - name: Compile all targets and features
+        run: cargo check --all-targets --all-features --locked
+
+  msrv:
+    name: Rust 1.85 compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install minimum supported Rust
+        run: rustup toolchain install 1.85.0 --profile minimal
+      - name: Check minimum supported Rust
+        run: cargo +1.85.0 check --all-features --locked
 
   security-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install stable Rust
         run: |
           rustup update stable
           rustup default stable
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo install cargo-audit --version 0.22.2 --locked
       - name: Audit locked dependencies
         run: cargo audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Validate tag and package version
+        id: version
+        shell: bash
+        run: |
+          [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          version="${GITHUB_REF_NAME#v}"
+          package_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+          test "$version" = "$package_version"
+          test -f "docs/releases/v${version}.md"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: validate
+    name: Build ${{ matrix.asset }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            asset: linux-amd64
+            binary: harlite
+            archive: tar.gz
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset: linux-arm64
+            binary: harlite
+            archive: tar.gz
+          - os: macos-15
+            target: aarch64-apple-darwin
+            asset: macos-arm64
+            binary: harlite
+            archive: tar.gz
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            asset: macos-amd64
+            binary: harlite
+            archive: tar.gz
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+            asset: windows-amd64
+            binary: harlite.exe
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install stable Rust
+        shell: bash
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup target add "${{ matrix.target }}"
+      - name: Build release binary
+        run: cargo build --release --all-features --locked --target ${{ matrix.target }}
+      - name: Smoke test binary
+        shell: bash
+        run: target/${{ matrix.target }}/release/${{ matrix.binary }} --version
+      - name: Package Unix archive
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          root="harlite-v${{ needs.validate.outputs.version }}-${{ matrix.asset }}"
+          mkdir -p "dist/$root"
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist/$root/"
+          cp README.md CHANGELOG.md LICENSE "dist/$root/"
+          tar -C dist -czf "dist/$root.tar.gz" "$root"
+          rm -rf "dist/$root"
+      - name: Package Windows archive
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $root = "harlite-v${{ needs.validate.outputs.version }}-${{ matrix.asset }}"
+          New-Item -ItemType Directory -Path "dist/$root" | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist/$root/"
+          Copy-Item README.md, CHANGELOG.md, LICENSE "dist/$root/"
+          Compress-Archive -Path "dist/$root" -DestinationPath "dist/$root.zip"
+          Remove-Item -Recurse "dist/$root"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.asset }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Validate and checksum release assets
+        shell: bash
+        run: |
+          test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 5
+          cd dist
+          sha256sum harlite-* > SHA256SUMS
+          sha256sum --check SHA256SUMS
+      - name: Attest archives and checksums
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: dist/*
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "harlite $GITHUB_REF_NAME" \
+            --notes-file "docs/releases/$GITHUB_REF_NAME.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,16 @@ Use the `harlite` binary to import HAR files into SQLite databases, then query/e
 - `schema` — print the SQLite schema (built-in or from a DB)
 - `info` — summarize database contents
 - `stats` — script-friendly stats output (text or JSON)
+- `analyze` — summarize timing/performance and enforce CI budgets
+- `check` — validate HAR semantics or database/blob/FTS integrity
 - `imports` — list import metadata
 - `prune` — remove a specific import by id
 - `export` — export a database back to HAR
 - `merge` — merge multiple databases into one
 - `redact` — redact sensitive headers/cookies/params/bodies
+- `pii` — scan/redact PII in HAR files or databases
 - `diff` — compare two HAR files or two databases
+- `request` — export requests as cURL/Fetch/node-fetch/PowerShell snippets
 - `report` — generate a self-contained HTML report (waterfall/slow/errors)
 
 ## Flags by command
@@ -70,6 +74,18 @@ Use the `harlite` binary to import HAR files into SQLite databases, then query/e
 - `--json`: JSON output
 - `<DATABASE>`: database to inspect
 
+### `analyze`
+- `--max-p95-total-ms <MS>` / `--max-p95-ttfb-ms <MS>`: fail if timing budgets are exceeded
+- `--max-errors <N>`: fail if the HTTP error count exceeds the budget
+- `<DATABASE>`: database to analyze
+
+### `check`
+- `--json`: JSON output
+- `--strict`: treat warnings as failures
+- `--allow-external-paths`: verify trusted external blob files
+- `--external-path-root <DIR>`: restrict external reads to this root
+- `<INPUT>`: HAR, database, or `-` for HAR stdin
+
 ### `export`
 - `-o, --output <OUTPUT>`: output HAR file (default: `<database>.har`, `-` for stdout)
 - `--bodies`: include stored request/response bodies
@@ -98,7 +114,7 @@ Use the `harlite` binary to import HAR files into SQLite databases, then query/e
 - `--dedup <hash|exact>`: entry deduplication strategy
 
 ### `redact`
-- `-o, --output <OUTPUT>`: output database (default: in-place)
+- `-o, --output <OUTPUT>`: output database/HAR (HAR defaults to a new sibling file)
 - `--force`: overwrite output db if it exists
 - `--dry-run`: report only, no writes
 - `--no-defaults`: disable default redaction patterns
@@ -124,6 +140,17 @@ Use the `harlite` binary to import HAR files into SQLite databases, then query/e
 - `--method <METHOD>`: HTTP method filter (repeatable)
 - `--status <STATUS>`: HTTP status filter (repeatable)
 - `--url-regex <REGEX>`: URL regex filter (repeatable)
+- `--fail-on <KIND>`: fail on any/added/changed/removed/new-errors/regression
+- `--max-total-regression-ms <MS>` / `--max-ttfb-regression-ms <MS>`: timing gates
+- `--max-response-size-increase <BYTES>` / `--max-new-errors <N>`: size/error gates
+- `--ignore-query-param <NAME>`: ignore a query parameter while matching
+
+### `request`
+- `--format <curl|fetch|node-fetch|powershell>`: snippet format
+- `--include-sensitive`: include sensitive headers (off by default)
+- `--index <N>` / `--limit <N>`: select requests
+- `--url-contains`, `--host`, `--method`, `--status`: request filters
+- `<INPUT>`: HAR, database, or `-` for HAR stdin
 
 ### `query`
 - `-f, --format <table|csv|json>`: output format
@@ -152,6 +179,7 @@ Use the `harlite` binary to import HAR files into SQLite databases, then query/e
 
 ## Working with data
 - The tool reads HAR files and writes SQLite `.db` files.
+- Use `-` as a HAR input for streaming commands; pass `--output` when a command must derive a filename.
 - Do not commit generated databases or large sample HAR files unless explicitly requested.
 ## Typical agent workflow
 1) `harlite import session.har -o traffic.db`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to harlite are documented here. The project follows Semantic Versioning.
+
+## [0.4.0] - 2026-07-13
+
+### Added
+
+- Native release archives for Linux AMD64/ARM64, macOS AMD64/ARM64, and Windows AMD64.
+- Keyless Sigstore-backed GitHub artifact attestations and SHA-256 checksums for release assets.
+- `harlite check` for HAR semantic validation and SQLite/blob/FTS integrity checks.
+- HAR-file support for `redact` and `pii`, including body and base64 response handling.
+- `analyze` and `diff` failure budgets for CI performance and regression gates.
+- `harlite request` exports captured requests as cURL, Fetch, node-fetch, or PowerShell snippets.
+- HAR input from standard input (`-`) across compatible commands.
+
+### Changed
+
+- CI now enforces formatting, strict Clippy, all-feature tests, minimal-feature builds, MSRV compatibility, package verification, dependency auditing, and native Linux ARM64/macOS/Windows compilation.
+- The CLI binary now uses the library crate directly instead of recompiling the implementation as duplicate modules.
+
+[0.4.0]: https://github.com/brucehart/harlite/releases/tag/v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -806,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "harlite"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -1079,6 +1079,7 @@ dependencies = [
  "notify",
  "opentelemetry-proto",
  "parquet",
+ "percent-encoding",
  "predicates",
  "prost",
  "regex",
@@ -1137,11 +1138,11 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2147,7 +2148,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2426,7 +2427,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2935,7 +2936,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harlite"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Import HAR files into SQLite. Query your web traffic with SQL."
@@ -16,6 +16,7 @@ include = [
     "Cargo.toml",
     "Cargo.lock",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE",
 ]
 
@@ -34,6 +35,7 @@ indicatif = "0.17"
 base64 = "0.22"
 bytes = "1"
 regex = "1"
+percent-encoding = "2"
 graphql-parser = { version = "0.4", optional = true }
 flate2 = { version = "1", optional = true }
 brotli = { version = "3", optional = true }

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ Works great with AI coding agents like Codex and Claude — they already know SQ
 - **Database merge** — Combine multiple harlite databases with deduplication (`harlite merge`)
 - **Queryable headers** — Headers stored as JSON, queryable with SQLite JSON functions
 - **Performance analysis** — Built-in timing analysis and caching insights (`harlite analyze`)
+- **Integrity validation** — Check HAR semantics, SQLite integrity, body hashes, and FTS references (`harlite check`)
 - **HTML reports** — Self-contained HTML report with waterfall + slow/errors (`harlite report`)
 - **Interactive REPL** — Explore databases with history, completions, and shortcuts (`harlite repl`)
-- **Safe sharing** — Redact sensitive headers/cookies before sharing a database
-- **PII scanning** — Find emails/phones/SSNs/credit cards in URLs and bodies (`harlite pii`)
-- **Diffing** — Compare two HAR files or two databases (`harlite diff`)
+- **Safe sharing** — Redact sensitive headers/cookies in HAR files or databases
+- **PII scanning** — Find and redact emails/phones/SSNs/credit cards in HAR files or databases (`harlite pii`)
+- **CI regression gates** — Enforce performance budgets with `analyze` and change budgets with `diff`
+- **Request snippets** — Export cURL, Fetch, node-fetch, or PowerShell commands (`harlite request`)
+- **Streaming input** — Read HAR JSON or compressed HAR data from standard input with `-`
 - **Replay** — Reissue requests against live servers and compare responses (`harlite replay`)
 - **HAR extensions preserved** — Store and round-trip HAR 1.3 extension fields as JSON
 - **CDP capture** — Capture from Chrome and write directly to HAR or SQLite
@@ -53,6 +56,17 @@ cargo install harlite
 ```
 
 Published on crates.io as `harlite`.
+
+### Download a native binary
+
+Release archives are available for Linux AMD64/ARM64, macOS AMD64/ARM64, and Windows AMD64 on the [GitHub Releases page](https://github.com/brucehart/harlite/releases/latest).
+
+Each archive includes `harlite`, `README.md`, `CHANGELOG.md`, and `LICENSE`. Releases also include `SHA256SUMS` and keyless Sigstore-backed GitHub artifact attestations:
+
+```bash
+grep 'harlite-v0.4.0-linux-amd64.tar.gz' SHA256SUMS | sha256sum --check -
+gh attestation verify harlite-v0.4.0-linux-amd64.tar.gz --repo brucehart/harlite
+```
 
 ## Feature flags
 
@@ -504,6 +518,23 @@ harlite analyze traffic.db --json
 # Filters + thresholds
 harlite analyze traffic.db --host api.example.com --from 2024-01-15 --to 2024-01-16 \
   --slow-total-ms 800 --slow-ttfb-ms 300 --top 20
+
+# Fail a CI job when a budget is exceeded
+harlite analyze traffic.db --json --max-p95-total-ms 800 \
+  --max-p95-ttfb-ms 300 --max-errors 0
+```
+
+### Validate HAR files and databases
+
+Check HAR semantics or database integrity before analysis, sharing, or release automation:
+
+```bash
+harlite check capture.har
+harlite check traffic.db --strict
+harlite check traffic.db --json
+
+# External bodies are never read unless explicitly trusted
+harlite check traffic.db --allow-external-paths --external-path-root ./extracted-bodies
 ```
 
 ### Imports list and prune
@@ -663,6 +694,10 @@ harlite diff before.db after.db --format json
 
 # Filter to specific hosts/paths/statuses
 harlite diff before.har after.har --host api.example.com --method GET --status 200 --url-regex 'example\\.com/api/'
+
+# Ignore cache-busting parameters and fail on new errors or slowdowns
+harlite diff before.har after.har --ignore-query-param cacheBust \
+  --fail-on new-errors --max-total-regression-ms 100 --max-new-errors 0
 ```
 
 Matching is done by `(method, url)` with a stable ordinal match per pair: if the same method+URL appears multiple times, the first occurrence in the left file is matched with the first in the right, the second with the second, and so on (ordered by HAR entry order or `started_at` for databases).
@@ -694,7 +729,7 @@ Safety: unsafe methods are skipped unless `--allow-unsafe` is set. Automatic red
 Redact common sensitive headers/cookies (by default: `authorization`, `cookie`, `set-cookie`, `x-api-key`, etc.) before sharing:
 
 ```bash
-# Modify in-place
+# Modify a database in-place
 harlite redact traffic.db
 
 # Write to a new database (recommended)
@@ -719,6 +754,13 @@ harlite redact traffic.db --body-regex '(?i)\"password\"\\s*:\\s*\"[^\"]+\"'
 # Read externally stored bodies only from an explicit trusted root
 harlite redact traffic.db --body-regex 'secret' --allow-external-paths \
   --external-path-root ./extracted-bodies
+
+# HAR files are written to a new sibling file by default
+harlite redact capture.har
+harlite redact capture.har --output capture.safe.har
+
+# Stream a redacted HAR to stdout; status details go to stderr
+cat capture.har | harlite redact - --output - > capture.safe.har
 ```
 
 Redaction removes superseded blobs and compacts the database, including its WAL, so old values are not left in ordinary SQLite free pages. External body paths are ignored unless explicitly enabled and contained by the selected root.
@@ -728,8 +770,9 @@ Redaction removes superseded blobs and compacts the database, including its WAL,
 Find emails, phone numbers, SSNs, and credit card numbers in URLs and stored bodies:
 
 ```bash
-# Scan and report findings
+# Scan and report findings in a database or HAR file
 harlite pii traffic.db
+harlite pii capture.har
 
 # JSON output for scripting
 harlite pii traffic.db --format json
@@ -737,14 +780,37 @@ harlite pii traffic.db --format json
 # Customize patterns (disable defaults, add your own)
 harlite pii traffic.db --no-defaults --email-regex '(?i)\\b.+@example\\.com\\b'
 
-# Auto-redact findings (write a new DB)
+# Auto-redact findings (write a new DB or HAR)
 harlite pii traffic.db --redact --output traffic.redacted.db
+harlite pii capture.har --redact --output capture.redacted.har
 
 # Scan trusted externally stored bodies
 harlite pii traffic.db --allow-external-paths --external-path-root ./extracted-bodies
 ```
 
 Defaults are conservative but may still produce false positives; review results before redacting. Use `--no-defaults` to opt out and supply your own regexes.
+
+### Export request snippets
+
+Turn captured requests into reproducible commands. Credential-bearing and transport-managed headers are excluded unless `--include-sensitive` is explicitly supplied.
+
+```bash
+harlite request capture.har --format curl --limit 5
+harlite request traffic.db --format fetch --host api.example.com
+harlite request capture.har --format node-fetch --index 2
+harlite request capture.har --format powershell --output requests.ps1
+```
+
+### Read HAR from standard input
+
+Use `-` where a compatible command expects a HAR path. Commands that create a file require an explicit output path because no filename can be derived from stdin.
+
+```bash
+cat capture.har | harlite import - --output traffic.db
+cat capture.har | harlite check - --strict
+cat capture.har | harlite request - --format curl
+cat capture.har | harlite report - --output report.html
+```
 
 ### Query with harlite
 

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,19 @@
+## Highlights
+
+harlite 0.4.0 makes captured traffic safer to share, easier to automate in CI, and available as a native download on the five most common desktop/server platforms.
+
+- Validate HAR files and databases with `harlite check`.
+- Redact secrets and scan/redact PII directly in HAR files as well as databases.
+- Export requests as cURL, Fetch, node-fetch, or PowerShell snippets with sensitive headers excluded by default.
+- Feed HAR data through standard input using `-`.
+- Fail CI when `analyze` performance budgets or `diff` regression budgets are exceeded.
+- Download native AMD64/ARM64 Linux, AMD64/ARM64 macOS, and AMD64 Windows archives.
+
+Each archive and `SHA256SUMS` is covered by a keyless GitHub artifact attestation backed by Sigstore. Verify a download with:
+
+```bash
+grep 'harlite-v0.4.0-linux-amd64.tar.gz' SHA256SUMS | sha256sum --check -
+gh attestation verify harlite-v0.4.0-linux-amd64.tar.gz --repo brucehart/harlite
+```
+
+See [CHANGELOG.md](https://github.com/brucehart/harlite/blob/v0.4.0/CHANGELOG.md) for the complete change summary.

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,14 +4,15 @@
 //! Treat the contents of this module as SemVer-stable.
 
 pub use crate::commands::{
-    run_analyze, run_diff, run_export, run_export_data, run_fts_rebuild, run_import, run_imports,
-    run_info, run_merge, run_openapi, run_pii, run_pii_with_external_paths, run_prune,
-    run_prune_with_options, run_query, run_redact, run_redact_with_external_paths, run_report,
-    run_schema, run_search, run_stats, run_waterfall, AnalyzeOptions, DataExportFormat,
-    DedupStrategy, DiffOptions, EntryFilterOptions, ExportDataOptions, ExportOptions, FtsTokenizer,
-    ImportOptions, InfoOptions, NameMatchMode, OpenApiOptions, OutputFormat, PiiOptions, PruneOptions,
-    QueryOptions, RedactOptions, ReportOptions, StatsOptions, WaterfallFormat, WaterfallGroupBy,
-    WaterfallOptions,
+    run_analyze, run_check, run_diff, run_export, run_export_data, run_fts_rebuild, run_import,
+    run_imports, run_info, run_merge, run_openapi, run_pii, run_pii_input,
+    run_pii_with_external_paths, run_prune, run_prune_with_options, run_query, run_redact,
+    run_redact_input, run_redact_with_external_paths, run_report, run_request_export, run_schema,
+    run_search, run_stats, run_waterfall, AnalyzeOptions, CheckOptions, DataExportFormat,
+    DedupStrategy, DiffFailOn, DiffOptions, EntryFilterOptions, ExportDataOptions, ExportOptions,
+    FtsTokenizer, ImportOptions, InfoOptions, NameMatchMode, OpenApiOptions, OutputFormat,
+    PiiOptions, PruneOptions, QueryOptions, RedactOptions, ReportOptions, RequestExportFormat,
+    RequestExportOptions, StatsOptions, WaterfallFormat, WaterfallGroupBy, WaterfallOptions,
 };
 #[cfg(feature = "cdp")]
 pub use crate::commands::{run_cdp, CdpOptions};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,8 +7,8 @@ use crate::commands::MatchMode;
 #[cfg(feature = "otel")]
 use crate::commands::OtelExportFormat;
 use crate::commands::{
-    DataExportFormat, DedupStrategy, ExportInputFormat, NameMatchMode, OutputFormat,
-    WaterfallFormat, WaterfallGroupBy,
+    DataExportFormat, DedupStrategy, DiffFailOn, ExportInputFormat, NameMatchMode, OutputFormat,
+    RequestExportFormat, WaterfallFormat, WaterfallGroupBy,
 };
 use crate::db::ExtractBodiesKind;
 
@@ -287,6 +287,28 @@ pub enum Commands {
     /// Print the resolved configuration
     Config,
 
+    /// Validate a HAR file or inspect a harlite database for integrity problems
+    Check {
+        /// HAR file, SQLite database, or '-' for HAR data on standard input
+        input: PathBuf,
+
+        /// Emit a structured JSON report
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        json: bool,
+
+        /// Treat warnings as validation failures
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        strict: bool,
+
+        /// Verify externally stored blob files
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        allow_external_paths: bool,
+
+        /// Trusted root for externally stored blob files
+        #[arg(long, requires = "allow_external_paths")]
+        external_path_root: Option<PathBuf>,
+    },
+
     /// Show information about a database
     Info {
         /// Database file to inspect
@@ -375,6 +397,18 @@ pub enum Commands {
         /// Limit for top N lists
         #[arg(long)]
         top: Option<usize>,
+
+        /// Fail when the total-time p95 exceeds this value in milliseconds
+        #[arg(long)]
+        max_p95_total_ms: Option<f64>,
+
+        /// Fail when the TTFB p95 exceeds this value in milliseconds
+        #[arg(long)]
+        max_p95_ttfb_ms: Option<f64>,
+
+        /// Fail when the number of HTTP 4xx/5xx responses exceeds this value
+        #[arg(long)]
+        max_errors: Option<usize>,
     },
 
     /// Export a HAR or harlite DB back to a HAR file
@@ -561,6 +595,60 @@ pub enum Commands {
         /// Maximum response body size (e.g., '100KB', '1.5MB', '1M', '100k', 'unlimited')
         #[arg(long)]
         max_response_size: Option<String>,
+    },
+
+    /// Export captured requests as cURL, Fetch, node-fetch, or PowerShell commands
+    Request {
+        /// HAR file, SQLite database, or '-' for HAR data on standard input
+        input: PathBuf,
+
+        /// Snippet format
+        #[arg(short, long, value_enum, default_value_t = RequestExportFormat::Curl)]
+        format: RequestExportFormat,
+
+        /// Output file (default: stdout; use '-' for stdout)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Overwrite an existing output file
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        force: bool,
+
+        /// Include credentials such as Authorization, Cookie, and API-key headers
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        include_sensitive: bool,
+
+        /// One-based index after filtering (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        index: Option<Vec<usize>>,
+
+        /// Maximum number of snippets to emit
+        #[arg(long)]
+        limit: Option<usize>,
+
+        /// URL substring filter (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        url_contains: Option<Vec<String>>,
+
+        /// Hostname filter (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        host: Option<Vec<String>>,
+
+        /// HTTP method filter (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        method: Option<Vec<String>>,
+
+        /// HTTP status filter (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        status: Option<Vec<i32>>,
+
+        /// Allow reading externally stored request bodies
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        allow_external_paths: bool,
+
+        /// Trusted root for externally stored request bodies
+        #[arg(long, requires = "allow_external_paths")]
+        external_path_root: Option<PathBuf>,
     },
 
     /// Export entries as OpenTelemetry spans
@@ -906,13 +994,13 @@ pub enum Commands {
         max_response_size: Option<String>,
     },
 
-    /// Redact sensitive headers/cookies in a harlite SQLite database
+    /// Redact sensitive headers, cookies, query parameters, and bodies in a HAR or database
     Redact {
-        /// Output database file (default: modify in-place)
+        /// Output file (database defaults to in-place; HAR gets a derived sibling path)
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Overwrite output database if it exists
+        /// Overwrite the output file if it exists
         #[arg(long, action = clap::ArgAction::SetTrue)]
         force: Option<bool>,
 
@@ -956,7 +1044,7 @@ pub enum Commands {
         #[arg(long, requires = "allow_external_paths")]
         external_path_root: Option<PathBuf>,
 
-        /// Database file to redact (default: the only *.db in the current directory)
+        /// HAR or database to redact; use '-' for HAR data on standard input
         database: Option<PathBuf>,
     },
 
@@ -970,11 +1058,11 @@ pub enum Commands {
         #[arg(long, action = clap::ArgAction::SetTrue)]
         redact: Option<bool>,
 
-        /// Output database file (default: modify in-place when --redact)
+        /// Output database or HAR file (database defaults to in-place; HAR gets a derived name)
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Overwrite output database if it exists
+        /// Overwrite the output file if it exists
         #[arg(long, action = clap::ArgAction::SetTrue)]
         force: Option<bool>,
 
@@ -1030,7 +1118,7 @@ pub enum Commands {
         #[arg(long, requires = "allow_external_paths")]
         external_path_root: Option<PathBuf>,
 
-        /// Database file to scan (default: the only *.db in the current directory)
+        /// HAR or database to scan; use '-' for HAR data on standard input
         database: Option<PathBuf>,
     },
 
@@ -1061,6 +1149,30 @@ pub enum Commands {
         /// URL regex match (repeatable)
         #[arg(long, action = clap::ArgAction::Append)]
         url_regex: Option<Vec<String>>,
+
+        /// Fail when a selected class of difference is present (repeatable)
+        #[arg(long, value_enum, action = clap::ArgAction::Append)]
+        fail_on: Option<Vec<DiffFailOn>>,
+
+        /// Fail when any total-time increase exceeds this many milliseconds
+        #[arg(long)]
+        max_total_regression_ms: Option<f64>,
+
+        /// Fail when any TTFB increase exceeds this many milliseconds
+        #[arg(long)]
+        max_ttfb_regression_ms: Option<f64>,
+
+        /// Fail when any response-body increase exceeds this many bytes
+        #[arg(long)]
+        max_response_size_increase: Option<i64>,
+
+        /// Fail when the number of newly introduced HTTP errors exceeds this value
+        #[arg(long)]
+        max_new_errors: Option<usize>,
+
+        /// Ignore this query parameter when matching requests (repeatable)
+        #[arg(long, action = clap::ArgAction::Append)]
+        ignore_query_param: Option<Vec<String>>,
     },
 
     /// Replay requests against live servers and compare responses

--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -20,6 +20,9 @@ pub struct AnalyzeOptions {
     pub slow_total_ms: f64,
     pub slow_ttfb_ms: f64,
     pub top: usize,
+    pub max_p95_total_ms: Option<f64>,
+    pub max_p95_ttfb_ms: Option<f64>,
+    pub max_errors: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -116,6 +119,7 @@ struct Bottleneck {
 #[derive(Debug, Serialize)]
 struct AnalyzeOutput {
     entries: usize,
+    error_entries: usize,
     filters: Filters,
     thresholds: Thresholds,
     aggregates: TimingAggregates,
@@ -126,6 +130,21 @@ struct AnalyzeOutput {
 }
 
 pub fn run_analyze(database: PathBuf, options: &AnalyzeOptions) -> Result<()> {
+    if !options.slow_total_ms.is_finite()
+        || options.slow_total_ms < 0.0
+        || !options.slow_ttfb_ms.is_finite()
+        || options.slow_ttfb_ms < 0.0
+        || options
+            .max_p95_total_ms
+            .is_some_and(|value| !value.is_finite() || value < 0.0)
+        || options
+            .max_p95_ttfb_ms
+            .is_some_and(|value| !value.is_finite() || value < 0.0)
+    {
+        return Err(HarliteError::InvalidArgs(
+            "Analyze timing thresholds must be finite and non-negative".to_string(),
+        ));
+    }
     let conn = Connection::open(&database)?;
     ensure_schema_upgrades(&conn)?;
 
@@ -138,12 +157,14 @@ pub fn run_analyze(database: PathBuf, options: &AnalyzeOptions) -> Result<()> {
         None => None,
     };
 
-    let mut query = EntryQuery::default();
-    query.hosts = options.host.clone();
-    query.methods = options.method.clone();
-    query.statuses = options.status.clone();
-    query.from_started_at = from_started_at.clone();
-    query.to_started_at = to_started_at.clone();
+    let query = EntryQuery {
+        hosts: options.host.clone(),
+        methods: options.method.clone(),
+        statuses: options.status.clone(),
+        from_started_at: from_started_at.clone(),
+        to_started_at: to_started_at.clone(),
+        ..EntryQuery::default()
+    };
 
     let entries = load_entries(&conn, &query)?;
 
@@ -173,14 +194,18 @@ pub fn run_analyze(database: PathBuf, options: &AnalyzeOptions) -> Result<()> {
         if let Some(value) = total_ms {
             totals.push(value);
             if value >= options.slow_total_ms {
-                slow_total.push(build_slow_entry(row, total_ms, ttfb_ms, dns_ms, connect_ms, ssl_ms));
+                slow_total.push(build_slow_entry(
+                    row, total_ms, ttfb_ms, dns_ms, connect_ms, ssl_ms,
+                ));
             }
         }
 
         if let Some(value) = ttfb_ms {
             ttfb.push(value);
             if value >= options.slow_ttfb_ms {
-                slow_ttfb.push(build_slow_entry(row, total_ms, ttfb_ms, dns_ms, connect_ms, ssl_ms));
+                slow_ttfb.push(build_slow_entry(
+                    row, total_ms, ttfb_ms, dns_ms, connect_ms, ssl_ms,
+                ));
             }
         }
 
@@ -262,6 +287,10 @@ pub fn run_analyze(database: PathBuf, options: &AnalyzeOptions) -> Result<()> {
 
     let output = AnalyzeOutput {
         entries: entries.len(),
+        error_entries: entries
+            .iter()
+            .filter(|entry| entry.status.is_some_and(|status| status >= 400))
+            .count(),
         filters: Filters {
             host: options.host.clone(),
             method: options.method.clone(),
@@ -278,8 +307,12 @@ pub fn run_analyze(database: PathBuf, options: &AnalyzeOptions) -> Result<()> {
         slow_requests: SlowRequests {
             total_ms: slow_total,
             ttfb_ms: slow_ttfb,
-            total_count: count_over_threshold(&entries, options.slow_total_ms, |r| normalize_ms(r.time_ms)),
-            ttfb_count: count_over_threshold(&entries, options.slow_ttfb_ms, |r| normalize_ms(r.wait_ms)),
+            total_count: count_over_threshold(&entries, options.slow_total_ms, |r| {
+                normalize_ms(r.time_ms)
+            }),
+            ttfb_count: count_over_threshold(&entries, options.slow_ttfb_ms, |r| {
+                normalize_ms(r.wait_ms)
+            }),
         },
         connection_reuse: reuse_stats,
         cache_candidates: CacheCandidates {
@@ -296,7 +329,42 @@ pub fn run_analyze(database: PathBuf, options: &AnalyzeOptions) -> Result<()> {
         render_text(&output);
     }
 
+    enforce_budgets(&output, options)?;
+
     Ok(())
+}
+
+fn enforce_budgets(output: &AnalyzeOutput, options: &AnalyzeOptions) -> Result<()> {
+    let mut violations = Vec::new();
+    if let (Some(limit), Some(stats)) = (options.max_p95_total_ms, &output.aggregates.total_ms) {
+        if stats.p95 > limit {
+            violations.push(format!(
+                "total p95 {:.2}ms exceeds {:.2}ms",
+                stats.p95, limit
+            ));
+        }
+    }
+    if let (Some(limit), Some(stats)) = (options.max_p95_ttfb_ms, &output.aggregates.ttfb_ms) {
+        if stats.p95 > limit {
+            violations.push(format!(
+                "TTFB p95 {:.2}ms exceeds {:.2}ms",
+                stats.p95, limit
+            ));
+        }
+    }
+    if let Some(limit) = options.max_errors {
+        if output.error_entries > limit {
+            violations.push(format!(
+                "{} error response(s) exceed the limit of {}",
+                output.error_entries, limit
+            ));
+        }
+    }
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(HarliteError::ThresholdExceeded(violations.join("; ")))
+    }
 }
 
 fn parse_started_at_bound(s: &str, is_end: bool) -> Result<String> {
@@ -446,9 +514,7 @@ fn is_cache_candidate(row: &EntryRow) -> bool {
         return false;
     }
     let headers = headers_from_json(row.response_headers.as_deref());
-    let cache_control = headers
-        .get("cache-control")
-        .map(|v| v.to_ascii_lowercase());
+    let cache_control = headers.get("cache-control").map(|v| v.to_ascii_lowercase());
     if let Some(control) = cache_control {
         if control.contains("no-store")
             || control.contains("no-cache")
@@ -518,13 +584,14 @@ where
 {
     entries
         .iter()
-        .filter_map(|row| fetch(row))
+        .filter_map(fetch)
         .filter(|v| *v >= threshold)
         .count()
 }
 
 fn render_text(output: &AnalyzeOutput) {
     println!("entries={}", output.entries);
+    println!("error_entries={}", output.error_entries);
     println!("filters.hosts={}", output.filters.host.join(","));
     println!("filters.methods={}", output.filters.method.join(","));
     let status_list = output
@@ -540,7 +607,10 @@ fn render_text(output: &AnalyzeOutput) {
         output.filters.from.as_deref().unwrap_or("")
     );
     println!("filters.to={}", output.filters.to.as_deref().unwrap_or(""));
-    println!("thresholds.slow_total_ms={}", output.thresholds.slow_total_ms);
+    println!(
+        "thresholds.slow_total_ms={}",
+        output.thresholds.slow_total_ms
+    );
     println!("thresholds.slow_ttfb_ms={}", output.thresholds.slow_ttfb_ms);
     println!("thresholds.top={}", output.thresholds.top);
 
@@ -558,7 +628,8 @@ fn render_text(output: &AnalyzeOutput) {
             "slow.total_ms={:.1} method={} status={} url={}",
             entry.total_ms.unwrap_or(0.0),
             entry.method,
-            entry.status
+            entry
+                .status
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| "-".to_string()),
             entry.url
@@ -571,7 +642,8 @@ fn render_text(output: &AnalyzeOutput) {
             "slow.ttfb_ms={:.1} method={} status={} url={}",
             entry.ttfb_ms.unwrap_or(0.0),
             entry.method,
-            entry.status
+            entry
+                .status
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| "-".to_string()),
             entry.url
@@ -626,14 +698,7 @@ fn print_stats_line(name: &str, stats: &Option<TimeStats>) {
     if let Some(stats) = stats {
         println!(
             "stats.{}=count:{} min:{:.1} p50:{:.1} p90:{:.1} p95:{:.1} avg:{:.1} max:{:.1}",
-            name,
-            stats.count,
-            stats.min,
-            stats.p50,
-            stats.p90,
-            stats.p95,
-            stats.avg,
-            stats.max
+            name, stats.count, stats.min, stats.p50, stats.p90, stats.p95, stats.avg, stats.max
         );
     } else {
         println!("stats.{}=count:0", name);

--- a/src/commands/cdp.rs
+++ b/src/commands/cdp.rs
@@ -274,20 +274,17 @@ fn select_target(base_url: &str, target_hint: Option<&str>) -> Result<TargetInfo
 
     if let Some(hint) = target_hint {
         let hint_lower = hint.to_lowercase();
-        candidates = candidates
-            .into_iter()
-            .filter(|t| {
-                t.id.eq_ignore_ascii_case(hint)
-                    || t.url
-                        .as_deref()
-                        .map(|u| u.to_lowercase().contains(&hint_lower))
-                        .unwrap_or(false)
-                    || t.title
-                        .as_deref()
-                        .map(|t| t.to_lowercase().contains(&hint_lower))
-                        .unwrap_or(false)
-            })
-            .collect();
+        candidates.retain(|t| {
+            t.id.eq_ignore_ascii_case(hint)
+                || t.url
+                    .as_deref()
+                    .map(|u| u.to_lowercase().contains(&hint_lower))
+                    .unwrap_or(false)
+                || t.title
+                    .as_deref()
+                    .map(|t| t.to_lowercase().contains(&hint_lower))
+                    .unwrap_or(false)
+        });
     }
 
     match candidates.len() {
@@ -305,9 +302,8 @@ fn set_socket_timeout(
     socket: &mut WebSocket<MaybeTlsStream<TcpStream>>,
     timeout: Duration,
 ) -> Result<()> {
-    match socket.get_mut() {
-        MaybeTlsStream::Plain(stream) => stream.set_read_timeout(Some(timeout))?,
-        _ => {}
+    if let MaybeTlsStream::Plain(stream) = socket.get_mut() {
+        stream.set_read_timeout(Some(timeout))?
     }
     Ok(())
 }
@@ -794,8 +790,13 @@ fn import_entries(path: &PathBuf, har: &Har, options: &CdpOptions) -> Result<()>
 
     let tx = conn.unchecked_transaction()?;
     for entry in &har.log.entries {
-        let entry_result =
-            insert_entry(&tx, import_id, entry, &entry_options, &EntryRelations::default())?;
+        let entry_result = insert_entry(
+            &tx,
+            import_id,
+            entry,
+            &entry_options,
+            &EntryRelations::default(),
+        )?;
         if entry_result.inserted {
             stats.entries_imported += 1;
             stats.request.add_assign(entry_result.blob_stats.request);

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -1,0 +1,657 @@
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use chrono::DateTime;
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+use url::Url;
+
+use crate::error::{HarliteError, Result};
+use crate::har::{parse_har_file, Entry, Har};
+
+use super::util::ExternalPathPolicy;
+
+#[derive(Clone, Debug, Default)]
+pub struct CheckOptions {
+    pub json: bool,
+    pub strict: bool,
+    pub allow_external_paths: bool,
+    pub external_path_root: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum InputKind {
+    Har,
+    Database,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct CheckStats {
+    entries: Option<u64>,
+    pages: Option<u64>,
+    imports: Option<u64>,
+    blobs: Option<u64>,
+    external_blobs: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckReport {
+    input: String,
+    input_kind: InputKind,
+    valid: bool,
+    errors: Vec<String>,
+    warnings: Vec<String>,
+    stats: CheckStats,
+}
+
+impl CheckReport {
+    fn new(input: &Path, input_kind: InputKind) -> Self {
+        Self {
+            input: if input == Path::new("-") {
+                "stdin".to_string()
+            } else {
+                input.display().to_string()
+            },
+            input_kind,
+            valid: true,
+            errors: Vec::new(),
+            warnings: Vec::new(),
+            stats: CheckStats::default(),
+        }
+    }
+
+    fn error(&mut self, message: impl Into<String>) {
+        self.errors.push(message.into());
+    }
+
+    fn warn(&mut self, message: impl Into<String>) {
+        self.warnings.push(message.into());
+    }
+
+    fn finish(&mut self, strict: bool) {
+        self.errors.sort();
+        self.errors.dedup();
+        self.warnings.sort();
+        self.warnings.dedup();
+        self.valid = self.errors.is_empty() && (!strict || self.warnings.is_empty());
+    }
+}
+
+pub fn run_check(input: PathBuf, options: &CheckOptions) -> Result<()> {
+    let kind = detect_input_kind(&input);
+    let mut report = match kind {
+        InputKind::Har => check_har(&input),
+        InputKind::Database => check_database(&input, options),
+    };
+    report.finish(options.strict);
+    write_report(&report, options.json)?;
+
+    let failures = report.errors.len()
+        + if options.strict {
+            report.warnings.len()
+        } else {
+            0
+        };
+    if failures > 0 {
+        return Err(HarliteError::ValidationFailed(failures));
+    }
+    Ok(())
+}
+
+fn detect_input_kind(path: &Path) -> InputKind {
+    if path == Path::new("-") {
+        return InputKind::Har;
+    }
+    if sqlite_magic(path) {
+        return InputKind::Database;
+    }
+    match path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("db" | "db3" | "sqlite" | "sqlite3") => InputKind::Database,
+        _ => InputKind::Har,
+    }
+}
+
+fn sqlite_magic(path: &Path) -> bool {
+    let Ok(mut file) = File::open(path) else {
+        return false;
+    };
+    let mut header = [0u8; 16];
+    file.read_exact(&mut header).is_ok() && header == *b"SQLite format 3\0"
+}
+
+fn check_har(path: &Path) -> CheckReport {
+    let mut report = CheckReport::new(path, InputKind::Har);
+    let har = match parse_har_file(path) {
+        Ok(har) => har,
+        Err(error) => {
+            report.error(error.to_string());
+            return report;
+        }
+    };
+
+    validate_har(&har, &mut report);
+    report
+}
+
+fn validate_har(har: &Har, report: &mut CheckReport) {
+    report.stats.entries = Some(har.log.entries.len() as u64);
+    report.stats.pages = Some(har.log.pages.as_ref().map_or(0, Vec::len) as u64);
+
+    match har.log.version.as_deref() {
+        Some("1.2") => {}
+        Some(version) => report.warn(format!(
+            "HAR version is {version}; 1.2 is the interoperable baseline"
+        )),
+        None => report.warn("HAR log.version is missing"),
+    }
+    if har.log.creator.is_none() {
+        report.warn("HAR log.creator is missing");
+    }
+    if har.log.entries.is_empty() {
+        report.warn("HAR contains no entries");
+    }
+
+    let mut page_ids = HashSet::new();
+    if let Some(pages) = &har.log.pages {
+        for (index, page) in pages.iter().enumerate() {
+            let context = format!("page {}", index + 1);
+            if page.id.trim().is_empty() {
+                report.error(format!("{context}: id is empty"));
+            } else if !page_ids.insert(page.id.clone()) {
+                report.error(format!("{context}: duplicate id '{}'", page.id));
+            }
+            validate_timestamp(
+                &page.started_date_time,
+                &format!("{context}.startedDateTime"),
+                report,
+            );
+        }
+    }
+
+    for (index, entry) in har.log.entries.iter().enumerate() {
+        validate_entry(index + 1, entry, &page_ids, report);
+    }
+}
+
+fn validate_entry(
+    index: usize,
+    entry: &Entry,
+    page_ids: &HashSet<String>,
+    report: &mut CheckReport,
+) {
+    let context = format!("entry {index}");
+    validate_timestamp(
+        &entry.started_date_time,
+        &format!("{context}.startedDateTime"),
+        report,
+    );
+
+    if !entry.time.is_finite() || entry.time < 0.0 {
+        report.error(format!(
+            "{context}: time must be a non-negative finite number"
+        ));
+    }
+    if entry.request.method.trim().is_empty() {
+        report.error(format!("{context}: request.method is empty"));
+    }
+    if entry.request.http_version.trim().is_empty() {
+        report.warn(format!("{context}: request.httpVersion is empty"));
+    }
+    if let Err(error) = Url::parse(&entry.request.url) {
+        report.error(format!("{context}: invalid request URL: {error}"));
+    }
+    if !(0..=999).contains(&entry.response.status) {
+        report.error(format!("{context}: response.status is outside 0..999"));
+    }
+    if entry.response.status == 0 {
+        report.warn(format!(
+            "{context}: response.status is 0 (request may be incomplete)"
+        ));
+    }
+    if entry.response.http_version.trim().is_empty() {
+        report.warn(format!("{context}: response.httpVersion is empty"));
+    }
+
+    validate_size(
+        entry.request.headers_size,
+        &format!("{context}.request.headersSize"),
+        report,
+    );
+    validate_size(
+        entry.request.body_size,
+        &format!("{context}.request.bodySize"),
+        report,
+    );
+    validate_size(
+        entry.response.headers_size,
+        &format!("{context}.response.headersSize"),
+        report,
+    );
+    validate_size(
+        entry.response.body_size,
+        &format!("{context}.response.bodySize"),
+        report,
+    );
+    validate_size(
+        Some(entry.response.content.size),
+        &format!("{context}.response.content.size"),
+        report,
+    );
+
+    for header in entry.request.headers.iter().chain(&entry.response.headers) {
+        if header.name.trim().is_empty() {
+            report.error(format!("{context}: header name is empty"));
+        }
+    }
+
+    if let Some(page_ref) = entry.pageref.as_deref() {
+        if !page_ids.contains(page_ref) {
+            report.warn(format!(
+                "{context}: pageref '{page_ref}' has no matching page"
+            ));
+        }
+    }
+
+    if let Some(timings) = &entry.timings {
+        for (name, value) in [
+            ("blocked", timings.blocked),
+            ("dns", timings.dns),
+            ("connect", timings.connect),
+            ("send", Some(timings.send)),
+            ("wait", Some(timings.wait)),
+            ("receive", Some(timings.receive)),
+            ("ssl", timings.ssl),
+        ] {
+            if let Some(value) = value {
+                if !value.is_finite() || (value < 0.0 && value != -1.0) {
+                    report.error(format!(
+                        "{context}: timing {name} must be -1 or non-negative"
+                    ));
+                }
+            }
+        }
+    }
+
+    if let Some(encoding) = entry.response.content.encoding.as_deref() {
+        match encoding.to_ascii_lowercase().as_str() {
+            "base64" => {
+                if let Some(text) = entry.response.content.text.as_deref() {
+                    if STANDARD.decode(text).is_err() {
+                        report.error(format!("{context}: response content is not valid base64"));
+                    }
+                } else {
+                    report.warn(format!(
+                        "{context}: base64 encoding is set but content.text is missing"
+                    ));
+                }
+            }
+            other => report.warn(format!(
+                "{context}: unrecognized response content encoding '{other}'"
+            )),
+        }
+    }
+}
+
+fn validate_timestamp(value: &str, field: &str, report: &mut CheckReport) {
+    if DateTime::parse_from_rfc3339(value).is_err() {
+        report.error(format!("{field} is not RFC3339"));
+    }
+}
+
+fn validate_size(value: Option<i64>, field: &str, report: &mut CheckReport) {
+    if value.is_some_and(|value| value < -1) {
+        report.error(format!("{field} must be -1 or non-negative"));
+    }
+}
+
+fn check_database(path: &Path, options: &CheckOptions) -> CheckReport {
+    let mut report = CheckReport::new(path, InputKind::Database);
+    let connection = match Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(connection) => connection,
+        Err(error) => {
+            report.error(error.to_string());
+            return report;
+        }
+    };
+    if let Err(error) = connection.execute_batch("PRAGMA query_only=ON") {
+        report.error(error.to_string());
+        return report;
+    }
+
+    if let Err(error) = check_database_inner(&connection, path, options, &mut report) {
+        report.error(error.to_string());
+    }
+    report
+}
+
+fn check_database_inner(
+    connection: &Connection,
+    path: &Path,
+    options: &CheckOptions,
+    report: &mut CheckReport,
+) -> Result<()> {
+    let tables = database_tables(connection)?;
+    for required in ["entries", "blobs", "pages", "imports"] {
+        if !tables.contains(required) {
+            report.error(format!("missing required table '{required}'"));
+        }
+    }
+    if !report.errors.is_empty() {
+        return Ok(());
+    }
+
+    // A database-wide quick_check invokes FTS5's integrity hook, which attempts
+    // an internal write and therefore fails on a deliberately read-only check.
+    // Check each ordinary table instead and validate FTS references below.
+    for table in ["entries", "blobs", "pages", "imports", "graphql_fields"] {
+        if !tables.contains(table) {
+            continue;
+        }
+        let mut quick_check = connection.prepare(&format!("PRAGMA quick_check('{table}')"))?;
+        let rows = quick_check.query_map([], |row| row.get::<_, String>(0))?;
+        for row in rows {
+            let message = row?;
+            if message != "ok" {
+                report.error(format!("SQLite quick_check({table}): {message}"));
+            }
+        }
+    }
+
+    let entry_columns = table_columns(connection, "entries")?;
+    for required in [
+        "id",
+        "import_id",
+        "started_at",
+        "method",
+        "url",
+        "status",
+        "request_body_hash",
+        "response_body_hash",
+        "entry_hash",
+    ] {
+        if !entry_columns.contains(required) {
+            report.error(format!(
+                "entries table is missing current column '{required}'"
+            ));
+        }
+    }
+
+    report.stats.entries = Some(query_count(connection, "entries")?);
+    report.stats.pages = Some(query_count(connection, "pages")?);
+    report.stats.imports = Some(query_count(connection, "imports")?);
+    report.stats.blobs = Some(query_count(connection, "blobs")?);
+
+    let foreign_key_failures: u64 =
+        connection.query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+            row.get(0)
+        })?;
+    if foreign_key_failures > 0 {
+        report.error(format!("{foreign_key_failures} foreign-key violation(s)"));
+    }
+
+    for (column, label) in [
+        ("request_body_hash", "request body"),
+        ("response_body_hash", "response body"),
+        ("response_body_hash_raw", "raw response body"),
+    ] {
+        if !entry_columns.contains(column) {
+            continue;
+        }
+        let sql = format!(
+            "SELECT COUNT(*) FROM entries e LEFT JOIN blobs b ON e.{column}=b.hash WHERE e.{column} IS NOT NULL AND b.hash IS NULL"
+        );
+        let count: u64 = connection.query_row(&sql, [], |row| row.get(0))?;
+        if count > 0 {
+            report.error(format!(
+                "{count} {label} reference(s) point to missing blobs"
+            ));
+        }
+    }
+
+    if tables.contains("response_body_fts") {
+        let missing: u64 = connection.query_row(
+            "SELECT COUNT(*) FROM response_body_fts f LEFT JOIN blobs b ON f.hash=b.hash WHERE b.hash IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        if missing > 0 {
+            report.error(format!("FTS contains {missing} hash(es) with no blob"));
+        }
+    } else {
+        report.warn("response_body_fts table is missing; run harlite fts-rebuild");
+    }
+
+    let incomplete: u64 = connection.query_row(
+        "SELECT COUNT(*) FROM imports WHERE COALESCE(status, '') != 'complete'",
+        [],
+        |row| row.get(0),
+    )?;
+    if incomplete > 0 {
+        report.warn(format!("{incomplete} import(s) are not marked complete"));
+    }
+
+    check_blobs(connection, path, options, report)?;
+    if tables.contains("response_body_fts") {
+        check_fts_contents(connection, path, options, report)?;
+    }
+    Ok(())
+}
+
+fn check_fts_contents(
+    connection: &Connection,
+    database: &Path,
+    options: &CheckOptions,
+    report: &mut CheckReport,
+) -> Result<()> {
+    let duplicates: u64 = connection.query_row(
+        "SELECT COUNT(*) FROM (SELECT hash FROM response_body_fts GROUP BY hash HAVING COUNT(*) > 1)",
+        [],
+        |row| row.get(0),
+    )?;
+    if duplicates > 0 {
+        report.error(format!(
+            "FTS contains {duplicates} duplicate blob hash(es); run harlite fts-rebuild"
+        ));
+    }
+
+    let policy = ExternalPathPolicy::new(
+        database,
+        options.allow_external_paths,
+        options.external_path_root.as_deref(),
+    )?;
+    let mut statement = connection.prepare(
+        "SELECT f.hash, f.body, b.content, b.size, b.external_path
+         FROM response_body_fts f JOIN blobs b ON f.hash=b.hash
+         ORDER BY f.hash",
+    )?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Vec<u8>>(2)?,
+            row.get::<_, i64>(3)?,
+            row.get::<_, Option<String>>(4)?,
+        ))
+    })?;
+
+    for row in rows {
+        let (hash, indexed_body, mut content, size, external_path) = row?;
+        let Some(indexed_body) = indexed_body else {
+            report.error(format!("FTS body for blob {hash} is NULL"));
+            continue;
+        };
+        if content.is_empty() && size > 0 {
+            if !options.allow_external_paths {
+                continue;
+            }
+            let Some(external_path) = external_path else {
+                continue;
+            };
+            let Some(path) = policy.resolve_file(&external_path) else {
+                continue;
+            };
+            let Ok(bytes) = std::fs::read(path) else {
+                continue;
+            };
+            content = bytes;
+        }
+        match std::str::from_utf8(&content) {
+            Ok(text) if text == indexed_body => {}
+            Ok(_) => report.error(format!(
+                "FTS body for blob {hash} does not match blob content; run harlite fts-rebuild"
+            )),
+            Err(_) => report.error(format!(
+                "FTS body for blob {hash} references non-UTF-8 content; run harlite fts-rebuild"
+            )),
+        }
+    }
+    Ok(())
+}
+
+fn database_tables(connection: &Connection) -> Result<HashSet<String>> {
+    let mut statement =
+        connection.prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    Ok(rows.collect::<std::result::Result<HashSet<_>, _>>()?)
+}
+
+fn table_columns(connection: &Connection, table: &str) -> Result<HashSet<String>> {
+    let mut statement = connection.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(1))?;
+    Ok(rows.collect::<std::result::Result<HashSet<_>, _>>()?)
+}
+
+fn query_count(connection: &Connection, table: &str) -> Result<u64> {
+    Ok(
+        connection.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })?,
+    )
+}
+
+fn check_blobs(
+    connection: &Connection,
+    database: &Path,
+    options: &CheckOptions,
+    report: &mut CheckReport,
+) -> Result<()> {
+    let policy = ExternalPathPolicy::new(
+        database,
+        options.allow_external_paths,
+        options.external_path_root.as_deref(),
+    )?;
+    let mut statement =
+        connection.prepare("SELECT hash, size, content, external_path FROM blobs ORDER BY hash")?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, Vec<u8>>(2)?,
+            row.get::<_, Option<String>>(3)?,
+        ))
+    })?;
+
+    let mut external_count = 0u64;
+    for row in rows {
+        let (hash, size, content, external_path) = row?;
+        if size < 0 {
+            report.error(format!("blob {hash}: size is negative"));
+        }
+        if !content.is_empty() {
+            validate_blob_bytes(&hash, size, &content, report);
+            continue;
+        }
+        if size == 0 {
+            validate_blob_bytes(&hash, size, &content, report);
+            if external_path.is_none() {
+                continue;
+            }
+        }
+        let Some(external_path) = external_path else {
+            report.error(format!(
+                "blob {hash}: content is empty and external_path is missing"
+            ));
+            continue;
+        };
+        external_count += 1;
+        if options.allow_external_paths {
+            match policy.resolve_file(&external_path) {
+                Some(path) => match std::fs::read(path) {
+                    Ok(bytes) => validate_blob_bytes(&hash, size, &bytes, report),
+                    Err(error) => report.error(format!(
+                        "blob {hash}: external content cannot be read: {error}"
+                    )),
+                },
+                None => report.error(format!(
+                    "blob {hash}: external_path is missing or outside the trusted root"
+                )),
+            }
+        }
+    }
+    report.stats.external_blobs = Some(external_count);
+    if external_count > 0 && !options.allow_external_paths {
+        report.warn(format!(
+            "{external_count} external blob(s) were not verified; use --allow-external-paths with --external-path-root"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_blob_bytes(hash: &str, size: i64, bytes: &[u8], report: &mut CheckReport) {
+    if size != bytes.len() as i64 {
+        report.error(format!(
+            "blob {hash}: recorded size {size} differs from {} bytes",
+            bytes.len()
+        ));
+    }
+    let actual_hash = blake3::hash(bytes).to_hex().to_string();
+    if actual_hash != hash {
+        report.error(format!("blob {hash}: content hash is {actual_hash}"));
+    }
+}
+
+fn write_report(report: &CheckReport, json: bool) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    if json {
+        serde_json::to_writer_pretty(&mut output, report)?;
+        writeln!(output)?;
+        return Ok(());
+    }
+
+    writeln!(output, "Input: {}", report.input)?;
+    writeln!(
+        output,
+        "Type: {}",
+        match report.input_kind {
+            InputKind::Har => "HAR",
+            InputKind::Database => "SQLite",
+        }
+    )?;
+    writeln!(output, "Valid: {}", if report.valid { "yes" } else { "no" })?;
+    if let Some(entries) = report.stats.entries {
+        writeln!(output, "Entries: {entries}")?;
+    }
+    if let Some(blobs) = report.stats.blobs {
+        writeln!(output, "Blobs: {blobs}")?;
+    }
+    for error in &report.errors {
+        writeln!(output, "ERROR: {error}")?;
+    }
+    for warning in &report.warnings {
+        writeln!(output, "WARNING: {warning}")?;
+    }
+    Ok(())
+}

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -3,9 +3,10 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
+use clap::ValueEnum;
 use regex::Regex;
 use rusqlite::{Connection, OpenFlags};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::db::{load_entries, EntryQuery, EntryRow};
@@ -14,12 +15,32 @@ use crate::har::{parse_har_file, Entry as HarEntry, Header};
 
 use super::{csv::write_csv_field, OutputFormat};
 
+const FLOAT_TOLERANCE: f64 = 1e-6;
+
 pub struct DiffOptions {
     pub format: OutputFormat,
     pub host: Vec<String>,
     pub method: Vec<String>,
     pub status: Vec<i32>,
     pub url_regex: Vec<String>,
+    pub fail_on: Vec<DiffFailOn>,
+    pub max_total_regression_ms: Option<f64>,
+    pub max_ttfb_regression_ms: Option<f64>,
+    pub max_response_size_increase: Option<i64>,
+    pub max_new_errors: Option<usize>,
+    pub ignore_query_params: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+#[clap(rename_all = "kebab-case")]
+pub enum DiffFailOn {
+    Any,
+    Added,
+    Changed,
+    Removed,
+    NewErrors,
+    Regression,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -74,6 +95,12 @@ struct Filters {
 }
 
 pub fn run_diff(left: PathBuf, right: PathBuf, options: &DiffOptions) -> Result<()> {
+    if left == Path::new("-") && right == Path::new("-") {
+        return Err(HarliteError::InvalidArgs(
+            "Only one diff input may read from standard input".to_string(),
+        ));
+    }
+    validate_gate_options(options)?;
     let left_is_db = is_db_path(&left);
     let right_is_db = is_db_path(&right);
     if left_is_db != right_is_db {
@@ -96,13 +123,33 @@ pub fn run_diff(left: PathBuf, right: PathBuf, options: &DiffOptions) -> Result<
         load_entries_from_har(&right, &filters)?
     };
 
-    let rows = diff_entries(left_entries, right_entries);
+    let rows = diff_entries(left_entries, right_entries, &options.ignore_query_params);
 
     match options.format {
         OutputFormat::Json => write_json(&rows),
         OutputFormat::Csv => write_csv(&rows),
         OutputFormat::Table => write_table(&rows),
+    }?;
+
+    enforce_diff_gates(&rows, options)
+}
+
+fn validate_gate_options(options: &DiffOptions) -> Result<()> {
+    if options
+        .max_total_regression_ms
+        .is_some_and(|value| !value.is_finite() || value < 0.0)
+        || options
+            .max_ttfb_regression_ms
+            .is_some_and(|value| !value.is_finite() || value < 0.0)
+        || options
+            .max_response_size_increase
+            .is_some_and(|value| value < 0)
+    {
+        return Err(HarliteError::InvalidArgs(
+            "Diff regression thresholds must be finite and non-negative".to_string(),
+        ));
     }
+    Ok(())
 }
 
 fn is_db_path(path: &Path) -> bool {
@@ -172,10 +219,10 @@ fn load_entries_from_db(
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
 
-    let mut query = EntryQuery::default();
-    query.hosts = options.host.clone();
-    query.methods = options.method.clone();
-    query.statuses = options.status.clone();
+    let query = EntryQuery {
+        statuses: options.status.clone(),
+        ..EntryQuery::default()
+    };
 
     let entries = load_entries(&conn, &query)?;
     Ok(entries
@@ -211,19 +258,18 @@ fn entry_matches_filters(entry: &EntrySnapshot, filters: &Filters) -> bool {
         return false;
     }
 
-    if !filters.status_set.is_empty() {
-        if entry
+    if !filters.status_set.is_empty()
+        && entry
             .status
             .is_none_or(|s| !filters.status_set.contains(&s))
-        {
-            return false;
-        }
+    {
+        return false;
     }
 
-    if !filters.url_regexes.is_empty() {
-        if entry.url.is_empty() || !filters.url_regexes.iter().any(|re| re.is_match(&entry.url)) {
-            return false;
-        }
+    if !filters.url_regexes.is_empty()
+        && (entry.url.is_empty() || !filters.url_regexes.iter().any(|re| re.is_match(&entry.url)))
+    {
+        return false;
     }
 
     true
@@ -347,14 +393,18 @@ fn headers_from_json(json: Option<&str>) -> HashMap<String, String> {
     map
 }
 
-fn diff_entries(left: Vec<EntrySnapshot>, right: Vec<EntrySnapshot>) -> Vec<DiffRow> {
+fn diff_entries(
+    left: Vec<EntrySnapshot>,
+    right: Vec<EntrySnapshot>,
+    ignore_query_params: &[String],
+) -> Vec<DiffRow> {
     let mut left_map: HashMap<EntryKey, Vec<EntrySnapshot>> = HashMap::new();
     let mut right_map: HashMap<EntryKey, Vec<EntrySnapshot>> = HashMap::new();
 
     for entry in left {
         let key = EntryKey {
             method: entry.method.clone(),
-            url: entry.url.clone(),
+            url: comparison_url(&entry.url, ignore_query_params),
         };
         left_map.entry(key).or_default().push(entry);
     }
@@ -362,7 +412,7 @@ fn diff_entries(left: Vec<EntrySnapshot>, right: Vec<EntrySnapshot>) -> Vec<Diff
     for entry in right {
         let key = EntryKey {
             method: entry.method.clone(),
-            url: entry.url.clone(),
+            url: comparison_url(&entry.url, ignore_query_params),
         };
         right_map.entry(key).or_default().push(entry);
     }
@@ -389,6 +439,142 @@ fn diff_entries(left: Vec<EntrySnapshot>, right: Vec<EntrySnapshot>) -> Vec<Diff
     }
 
     rows
+}
+
+fn comparison_url(raw: &str, ignored_params: &[String]) -> String {
+    if ignored_params.is_empty() {
+        return raw.to_string();
+    }
+    let ignored: HashSet<String> = ignored_params
+        .iter()
+        .map(|name| name.to_ascii_lowercase())
+        .collect();
+    let (without_fragment, fragment) = raw
+        .split_once('#')
+        .map(|(url, fragment)| (url, Some(fragment)))
+        .unwrap_or((raw, None));
+    let Some((prefix, query)) = without_fragment.split_once('?') else {
+        return raw.to_string();
+    };
+    let mut removed = false;
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|pair| {
+            let raw_name = pair.split_once('=').map_or(*pair, |(name, _)| name);
+            let decoded_name = url::form_urlencoded::parse(raw_name.as_bytes())
+                .next()
+                .map(|(name, _)| name.into_owned())
+                .unwrap_or_else(|| raw_name.to_string());
+            let should_remove = ignored.contains(&decoded_name.to_ascii_lowercase());
+            removed |= should_remove;
+            !should_remove
+        })
+        .collect();
+    if !removed {
+        return raw.to_string();
+    }
+
+    let mut result = prefix.to_string();
+    if !kept.is_empty() {
+        result.push('?');
+        result.push_str(&kept.join("&"));
+    }
+    if let Some(fragment) = fragment {
+        result.push('#');
+        result.push_str(fragment);
+    }
+    result
+}
+
+fn enforce_diff_gates(rows: &[DiffRow], options: &DiffOptions) -> Result<()> {
+    let added = rows.iter().filter(|row| row.change == "added").count();
+    let changed = rows.iter().filter(|row| row.change == "changed").count();
+    let removed = rows.iter().filter(|row| row.change == "removed").count();
+    let new_errors = rows
+        .iter()
+        .filter(|row| {
+            row.status_right.is_some_and(|status| status >= 400)
+                && row.status_left.is_none_or(|status| status < 400)
+        })
+        .count();
+    let regressions = rows
+        .iter()
+        .filter(|row| {
+            row.delta_total_ms
+                .is_some_and(|delta| regression_exceeds(delta, 0.0))
+                || row
+                    .delta_ttfb_ms
+                    .is_some_and(|delta| regression_exceeds(delta, 0.0))
+                || row.delta_response_body_size.is_some_and(|delta| delta > 0)
+        })
+        .count();
+
+    let mut violations = Vec::new();
+    for condition in &options.fail_on {
+        let (count, label) = match condition {
+            DiffFailOn::Any => (rows.len(), "difference(s)"),
+            DiffFailOn::Added => (added, "added request(s)"),
+            DiffFailOn::Changed => (changed, "changed request(s)"),
+            DiffFailOn::Removed => (removed, "removed request(s)"),
+            DiffFailOn::NewErrors => (new_errors, "new HTTP error(s)"),
+            DiffFailOn::Regression => (regressions, "regression(s)"),
+        };
+        if count > 0 {
+            violations.push(format!("{count} {label}"));
+        }
+    }
+
+    if let Some(limit) = options.max_new_errors {
+        if new_errors > limit {
+            violations.push(format!("{new_errors} new HTTP error(s) exceed {limit}"));
+        }
+    }
+    if let Some(limit) = options.max_total_regression_ms {
+        let count = rows
+            .iter()
+            .filter(|row| {
+                row.delta_total_ms
+                    .is_some_and(|delta| regression_exceeds(delta, limit))
+            })
+            .count();
+        if count > 0 {
+            violations.push(format!(
+                "{count} total-time regression(s) exceed {limit:.2}ms"
+            ));
+        }
+    }
+    if let Some(limit) = options.max_ttfb_regression_ms {
+        let count = rows
+            .iter()
+            .filter(|row| {
+                row.delta_ttfb_ms
+                    .is_some_and(|delta| regression_exceeds(delta, limit))
+            })
+            .count();
+        if count > 0 {
+            violations.push(format!("{count} TTFB regression(s) exceed {limit:.2}ms"));
+        }
+    }
+    if let Some(limit) = options.max_response_size_increase {
+        let count = rows
+            .iter()
+            .filter(|row| {
+                row.delta_response_body_size
+                    .is_some_and(|delta| delta > limit)
+            })
+            .count();
+        if count > 0 {
+            violations.push(format!(
+                "{count} response-size increase(s) exceed {limit} bytes"
+            ));
+        }
+    }
+
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(HarliteError::ThresholdExceeded(violations.join("; ")))
+    }
 }
 
 fn diff_entry(left: Option<&EntrySnapshot>, right: Option<&EntrySnapshot>) -> Option<DiffRow> {
@@ -497,9 +683,13 @@ fn count_header_changes(left: &HashMap<String, String>, right: &HashMap<String, 
 fn f64_changed(left: Option<f64>, right: Option<f64>) -> bool {
     match (left, right) {
         (None, None) => false,
-        (Some(a), Some(b)) => (a - b).abs() > 1e-6,
+        (Some(a), Some(b)) => (a - b).abs() > FLOAT_TOLERANCE,
         _ => true,
     }
+}
+
+fn regression_exceeds(delta: f64, limit: f64) -> bool {
+    delta - limit > FLOAT_TOLERANCE
 }
 
 fn diff_f64(left: Option<f64>, right: Option<f64>) -> Option<f64> {
@@ -550,7 +740,7 @@ fn write_table(rows: &[DiffRow]) -> Result<()> {
     }
 
     for width in &mut widths {
-        *width = (*width).min(80).max(8);
+        *width = (*width).clamp(8, 80);
     }
 
     let mut out = io::stdout().lock();
@@ -630,8 +820,7 @@ fn write_table_row<'a, I>(out: &mut impl Write, fields: I, widths: &[usize]) -> 
 where
     I: IntoIterator<Item = &'a str>,
 {
-    let mut i = 0usize;
-    for field in fields {
+    for (i, field) in fields.into_iter().enumerate() {
         if i > 0 {
             out.write_all(b" | ")?;
         }
@@ -642,7 +831,6 @@ where
         if field_len < width {
             out.write_all(" ".repeat(width - field_len).as_bytes())?;
         }
-        i += 1;
     }
     out.write_all(b"\n")?;
     Ok(())

--- a/src/commands/entry_filter.rs
+++ b/src/commands/entry_filter.rs
@@ -45,10 +45,9 @@ pub fn load_entries_with_filters(
 
     let mut query = EntryQuery::default();
     let import_ids = load_import_ids_by_source(conn, &options.source, &options.source_contains)?;
-    if !options.source.is_empty() || !options.source_contains.is_empty() {
-        if import_ids.is_empty() {
-            return Ok(Vec::new());
-        }
+    if (!options.source.is_empty() || !options.source_contains.is_empty()) && import_ids.is_empty()
+    {
+        return Ok(Vec::new());
     }
     if !import_ids.is_empty() {
         query.import_ids = import_ids;
@@ -173,8 +172,7 @@ fn load_import_ids_by_source(
     }
 
     if !source_contains.is_empty() {
-        let joined = std::iter::repeat("source_file LIKE '%' || ? || '%'")
-            .take(source_contains.len())
+        let joined = std::iter::repeat_n("source_file LIKE '%' || ? || '%'", source_contains.len())
             .collect::<Vec<_>>()
             .join(" OR ");
         clauses.push(format!("({joined})"));

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -224,6 +224,11 @@ fn open_output(path: &Path) -> Result<Box<dyn Write>> {
 /// Export a harlite database or HAR back to a HAR file.
 pub fn run_export(database: PathBuf, options: &ExportOptions) -> Result<()> {
     let input_format = resolve_export_format(&database, options.format)?;
+    if database == Path::new("-") && options.output.is_none() {
+        return Err(HarliteError::InvalidArgs(
+            "Reading a HAR from standard input requires --output".to_string(),
+        ));
+    }
     let output_path = options
         .output
         .clone()
@@ -474,8 +479,7 @@ fn run_export_from_db(database: &Path, output_path: &Path, options: &ExportOptio
             || row.wait_ms.is_some()
             || row.receive_ms.is_some();
         let wait_ms =
-            normalize_ms(row.wait_ms)
-                .unwrap_or_else(|| if has_timing_parts { 0.0 } else { time_ms });
+            normalize_ms(row.wait_ms).unwrap_or(if has_timing_parts { 0.0 } else { time_ms });
         let timings = Some(Timings {
             blocked: normalize_ms(row.blocked_ms),
             dns: normalize_ms(row.dns_ms),
@@ -720,6 +724,7 @@ fn run_export_from_har(database: &Path, output_path: &Path, options: &ExportOpti
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn matches_har_filters(
     entry: &Entry,
     url: &[String],
@@ -952,6 +957,9 @@ fn resolve_export_format(
 }
 
 fn detect_export_format(path: &Path) -> Result<ExportInputFormat> {
+    if path == Path::new("-") {
+        return Ok(ExportInputFormat::Har);
+    }
     if is_db_path(path) {
         return Ok(ExportInputFormat::Db);
     }

--- a/src/commands/export_data.rs
+++ b/src/commands/export_data.rs
@@ -8,8 +8,8 @@ use rusqlite::Connection;
 use crate::db::{ensure_schema_upgrades, EntryRow};
 use crate::error::{HarliteError, Result};
 
-use super::entry_filter::{load_entries_with_filters, EntryFilterOptions};
 use super::csv::write_csv_field;
+use super::entry_filter::{load_entries_with_filters, EntryFilterOptions};
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[clap(rename_all = "kebab-case")]
@@ -52,7 +52,9 @@ pub fn run_export_data(database: PathBuf, options: &ExportDataOptions) -> Result
         }
     };
 
-    if matches!(options.format, DataExportFormat::Parquet) && output_path == PathBuf::from("-") {
+    if matches!(options.format, DataExportFormat::Parquet)
+        && output_path == std::path::Path::new("-")
+    {
         return Err(HarliteError::InvalidArgs(
             "Parquet export requires a file path; '-' is not supported".to_string(),
         ));
@@ -70,7 +72,7 @@ pub fn run_export_data(database: PathBuf, options: &ExportDataOptions) -> Result
         DataExportFormat::Parquet => write_parquet(&output_path, &entries)?,
     }
 
-    if output_path != PathBuf::from("-") {
+    if output_path != std::path::Path::new("-") {
         println!(
             "Exported {} entries to {}",
             entries.len(),
@@ -379,196 +381,248 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
         .with_fields(vec![
             Type::primitive_type_builder("import_id", PhysicalType::INT64)
                 .with_repetition(Repetition::REQUIRED)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("page_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("started_at", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("time_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("blocked_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("dns_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("connect_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("send_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("wait_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("receive_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("ssl_ms", PhysicalType::DOUBLE)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("method", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("url", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("host", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("path", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("query_string", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("http_version", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("request_headers", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("request_cookies", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("request_body_hash", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("request_body_size", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("status", PhysicalType::INT32)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("status_text", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_headers", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_cookies", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_body_hash", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_body_size", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_body_hash_raw", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_body_size_raw", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_mime_type", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("is_redirect", PhysicalType::INT32)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("server_ip", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("connection_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("request_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("parent_request_id", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("initiator_type", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("initiator_url", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("initiator_line", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("initiator_column", PhysicalType::INT64)
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("redirect_url", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("tls_version", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("tls_cipher_suite", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("tls_cert_subject", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("tls_cert_issuer", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("tls_cert_expiry", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("entry_hash", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("entry_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("request_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("response_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("content_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("timings_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
             Type::primitive_type_builder("post_data_extensions", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(parquet::basic::LogicalType::String))
                 .with_repetition(Repetition::OPTIONAL)
-                .build()?.into(),
+                .build()?
+                .into(),
         ])
         .build()?;
 
@@ -582,7 +636,10 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
         row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
         values: Vec<Option<String>>,
     ) -> Result<()> {
-        let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
+        let def_levels: Vec<i16> = values
+            .iter()
+            .map(|v| if v.is_some() { 1 } else { 0 })
+            .collect();
         let data: Vec<ByteArray> = values
             .into_iter()
             .filter_map(|v| v.map(|s| ByteArray::from(s.into_bytes())))
@@ -607,8 +664,11 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
         row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
         values: Vec<Option<i64>>,
     ) -> Result<()> {
-        let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
-        let data: Vec<i64> = values.into_iter().filter_map(|v| v).collect();
+        let def_levels: Vec<i16> = values
+            .iter()
+            .map(|v| if v.is_some() { 1 } else { 0 })
+            .collect();
+        let data: Vec<i64> = values.into_iter().flatten().collect();
         if let Some(mut col_writer) = row_group_writer.next_column()? {
             match col_writer.untyped() {
                 ColumnWriter::Int64ColumnWriter(w) => {
@@ -629,8 +689,11 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
         row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
         values: Vec<Option<i32>>,
     ) -> Result<()> {
-        let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
-        let data: Vec<i32> = values.into_iter().filter_map(|v| v).collect();
+        let def_levels: Vec<i16> = values
+            .iter()
+            .map(|v| if v.is_some() { 1 } else { 0 })
+            .collect();
+        let data: Vec<i32> = values.into_iter().flatten().collect();
         if let Some(mut col_writer) = row_group_writer.next_column()? {
             match col_writer.untyped() {
                 ColumnWriter::Int32ColumnWriter(w) => {
@@ -651,8 +714,11 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
         row_group_writer: &mut SerializedRowGroupWriter<'_, W>,
         values: Vec<Option<f64>>,
     ) -> Result<()> {
-        let def_levels: Vec<i16> = values.iter().map(|v| if v.is_some() { 1 } else { 0 }).collect();
-        let data: Vec<f64> = values.into_iter().filter_map(|v| v).collect();
+        let def_levels: Vec<i16> = values
+            .iter()
+            .map(|v| if v.is_some() { 1 } else { 0 })
+            .collect();
+        let data: Vec<f64> = values.into_iter().flatten().collect();
         if let Some(mut col_writer) = row_group_writer.next_column()? {
             match col_writer.untyped() {
                 ColumnWriter::DoubleColumnWriter(w) => {
@@ -685,57 +751,240 @@ fn write_parquet(path: &Path, entries: &[EntryRow]) -> Result<()> {
         col_writer.close()?;
     }
 
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.page_id.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.started_at.clone()).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.time_ms).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.blocked_ms).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.dns_ms).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.connect_ms).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.send_ms).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.wait_ms).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.receive_ms).collect())?;
-    write_f64_col(&mut row_group_writer, entries.iter().map(|e| e.ssl_ms).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.method.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.url.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.host.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.path.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.query_string.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.http_version.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_headers.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_cookies.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_body_hash.clone()).collect())?;
-    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.request_body_size).collect())?;
-    write_i32_col(&mut row_group_writer, entries.iter().map(|e| e.status).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.status_text.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_headers.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_cookies.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_hash.clone()).collect())?;
-    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_size).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_hash_raw.clone()).collect())?;
-    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.response_body_size_raw).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_mime_type.clone()).collect())?;
-    write_i32_col(&mut row_group_writer, entries.iter().map(|e| e.is_redirect).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.server_ip.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.connection_id.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_id.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.parent_request_id.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_type.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_url.clone()).collect())?;
-    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_line).collect())?;
-    write_i64_col(&mut row_group_writer, entries.iter().map(|e| e.initiator_column).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.redirect_url.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_version.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cipher_suite.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cert_subject.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cert_issuer.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.tls_cert_expiry.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.entry_hash.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.entry_extensions.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.request_extensions.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.response_extensions.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.content_extensions.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.timings_extensions.clone()).collect())?;
-    write_string_col(&mut row_group_writer, entries.iter().map(|e| e.post_data_extensions.clone()).collect())?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.page_id.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.started_at.clone()).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.time_ms).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.blocked_ms).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.dns_ms).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.connect_ms).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.send_ms).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.wait_ms).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.receive_ms).collect(),
+    )?;
+    write_f64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.ssl_ms).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.method.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.url.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.host.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.path.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.query_string.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.http_version.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.request_headers.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.request_cookies.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.request_body_hash.clone())
+            .collect(),
+    )?;
+    write_i64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.request_body_size).collect(),
+    )?;
+    write_i32_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.status).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.status_text.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.response_headers.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.response_cookies.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.response_body_hash.clone())
+            .collect(),
+    )?;
+    write_i64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.response_body_size).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.response_body_hash_raw.clone())
+            .collect(),
+    )?;
+    write_i64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.response_body_size_raw).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.response_mime_type.clone())
+            .collect(),
+    )?;
+    write_i32_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.is_redirect).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.server_ip.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.connection_id.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.request_id.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.parent_request_id.clone())
+            .collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.initiator_type.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.initiator_url.clone()).collect(),
+    )?;
+    write_i64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.initiator_line).collect(),
+    )?;
+    write_i64_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.initiator_column).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.redirect_url.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.tls_version.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.tls_cipher_suite.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.tls_cert_subject.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.tls_cert_issuer.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.tls_cert_expiry.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.entry_hash.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries.iter().map(|e| e.entry_extensions.clone()).collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.request_extensions.clone())
+            .collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.response_extensions.clone())
+            .collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.content_extensions.clone())
+            .collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.timings_extensions.clone())
+            .collect(),
+    )?;
+    write_string_col(
+        &mut row_group_writer,
+        entries
+            .iter()
+            .map(|e| e.post_data_extensions.clone())
+            .collect(),
+    )?;
 
     row_group_writer.close()?;
     writer.close()?;

--- a/src/commands/fts.rs
+++ b/src/commands/fts.rs
@@ -101,10 +101,8 @@ pub fn run_fts_rebuild(
     let hashes_iter = stmt.query_map([], |row| row.get::<_, String>(0))?;
 
     let mut hashes: Vec<String> = Vec::new();
-    for h in hashes_iter {
-        if let Ok(hash) = h {
-            hashes.push(hash);
-        }
+    for hash in hashes_iter.flatten() {
+        hashes.push(hash);
     }
 
     // Keep ordering stable, but dedup defensively.

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -152,6 +152,21 @@ pub fn run_import(files: &[PathBuf], options: &ImportOptions) -> Result<ImportSt
         ));
     }
 
+    let stdin_count = files
+        .iter()
+        .filter(|path| path.as_path() == Path::new("-"))
+        .count();
+    if stdin_count > 1 || (stdin_count == 1 && files.len() != 1) {
+        return Err(HarliteError::InvalidArgs(
+            "Standard input ('-') must be the only import source".to_string(),
+        ));
+    }
+    if stdin_count == 1 && options.output.is_none() {
+        return Err(HarliteError::InvalidArgs(
+            "Importing from standard input requires --output".to_string(),
+        ));
+    }
+
     let output_path = match &options.output {
         Some(p) => p.clone(),
         None => {
@@ -457,6 +472,9 @@ fn setup_connection(conn: &Connection) -> Result<()> {
 }
 
 fn source_key(path: &Path) -> String {
+    if path == Path::new("-") {
+        return "stdin".to_string();
+    }
     path.canonicalize()
         .unwrap_or_else(|_| path.to_path_buf())
         .to_string_lossy()
@@ -484,7 +502,7 @@ fn resolve_jobs(file_count: usize, requested: usize) -> usize {
         let cpus = thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1);
-        cpus.min(4).max(1)
+        cpus.clamp(1, 4)
     };
     jobs.min(file_count).max(1)
 }
@@ -809,16 +827,22 @@ fn entry_matches_filters(entry: &Entry, filters: &ImportFilters) -> Result<bool>
 }
 
 fn extract_request_id(entry: &Entry) -> Option<String> {
-    extension_string(&entry.extensions, &["_requestId", "requestId", "request_id"])
-        .or_else(|| {
-            extension_string(&entry.request.extensions, &["_requestId", "requestId", "request_id"])
-        })
-        .or_else(|| {
-            extension_string(
-                &entry.response.extensions,
-                &["_requestId", "requestId", "request_id"],
-            )
-        })
+    extension_string(
+        &entry.extensions,
+        &["_requestId", "requestId", "request_id"],
+    )
+    .or_else(|| {
+        extension_string(
+            &entry.request.extensions,
+            &["_requestId", "requestId", "request_id"],
+        )
+    })
+    .or_else(|| {
+        extension_string(
+            &entry.response.extensions,
+            &["_requestId", "requestId", "request_id"],
+        )
+    })
 }
 
 fn extract_initiator(entry: &Entry) -> InitiatorInfo {
@@ -830,15 +854,21 @@ fn extract_initiator(entry: &Entry) -> InitiatorInfo {
         return InitiatorInfo::default();
     };
 
-    let mut info = InitiatorInfo::default();
-    info.initiator_type = value_string(map.get("type"));
-    info.parent_request_id = value_string_by_keys(
-        map,
-        &["requestId", "request_id", "parentRequestId", "parent_request_id"],
-    );
-    info.initiator_url = value_string_by_keys(map, &["url", "initiatorUrl", "sourceURL"]);
-    info.initiator_line = value_i64_by_keys(map, &["lineNumber", "line"]);
-    info.initiator_column = value_i64_by_keys(map, &["columnNumber", "column"]);
+    let mut info = InitiatorInfo {
+        initiator_type: value_string(map.get("type")),
+        parent_request_id: value_string_by_keys(
+            map,
+            &[
+                "requestId",
+                "request_id",
+                "parentRequestId",
+                "parent_request_id",
+            ],
+        ),
+        initiator_url: value_string_by_keys(map, &["url", "initiatorUrl", "sourceURL"]),
+        initiator_line: value_i64_by_keys(map, &["lineNumber", "line"]),
+        initiator_column: value_i64_by_keys(map, &["columnNumber", "column"]),
+    };
 
     if info.initiator_url.is_none()
         || info.initiator_line.is_none()
@@ -924,10 +954,7 @@ fn value_string(value: Option<&Value>) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-fn value_string_by_keys(
-    map: &serde_json::Map<String, Value>,
-    keys: &[&str],
-) -> Option<String> {
+fn value_string_by_keys(map: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
     for key in keys {
         if let Some(value) = map.get(*key) {
             if let Some(s) = value.as_str() {
@@ -968,7 +995,9 @@ fn stack_frame_from_value(value: &Value) -> Option<StackFrame> {
     let obj = value.as_object()?;
     if let Some(frames) = obj.get("callFrames").and_then(|v| v.as_array()) {
         for frame in frames {
-            let Some(frame_obj) = frame.as_object() else { continue };
+            let Some(frame_obj) = frame.as_object() else {
+                continue;
+            };
             let Some(url) = value_string(frame_obj.get("url")) else {
                 continue;
             };

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -102,7 +102,10 @@ pub fn run_info(database: PathBuf, options: &InfoOptions) -> Result<()> {
 
         println!("\nRequest chains:");
         println!("  Requests with request_id: {}", request_id_count);
-        println!("  Requests with parent_request_id: {}", parent_request_count);
+        println!(
+            "  Requests with parent_request_id: {}",
+            parent_request_count
+        );
         println!("  Parent request ids: {}", parent_roots);
         println!("  Redirects (redirect_url set): {}", redirect_count);
 
@@ -111,7 +114,9 @@ pub fn run_info(database: PathBuf, options: &InfoOptions) -> Result<()> {
              FROM entries WHERE initiator_type IS NOT NULL \
              GROUP BY initiator_type ORDER BY cnt DESC LIMIT 5",
         )?;
-        let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
         let mut initiators = Vec::new();
         for row in rows {
             initiators.push(row?);

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -437,7 +437,7 @@ fn resolve_output_path(databases: &[PathBuf], output: Option<&PathBuf>) -> Resul
     }
 
     let first = databases
-        .get(0)
+        .first()
         .ok_or_else(|| HarliteError::InvalidArgs("No input databases".to_string()))?;
     let stem = first
         .file_stem()
@@ -576,8 +576,10 @@ fn load_entry_keys_for_import(
     import_id: i64,
     strategy: DedupStrategy,
 ) -> Result<HashMap<EntryKey, i64>> {
-    let sql = format!("SELECT id, {} FROM entries WHERE import_id = ?1", 
-        ENTRY_COLUMNS.iter()
+    let sql = format!(
+        "SELECT id, {} FROM entries WHERE import_id = ?1",
+        ENTRY_COLUMNS
+            .iter()
             .map(|col| select_col(columns, col))
             .collect::<Vec<_>>()
             .join(", ")
@@ -986,10 +988,8 @@ fn load_existing_fts_hashes(conn: &Connection) -> Result<HashSet<String>> {
     let mut stmt = conn.prepare("SELECT hash FROM response_body_fts")?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
     let mut out = HashSet::new();
-    for row in rows {
-        if let Ok(hash) = row {
-            out.insert(hash);
-        }
+    for hash in rows.flatten() {
+        out.insert(hash);
     }
     Ok(out)
 }
@@ -1000,7 +1000,9 @@ fn load_graphql_fields(conn: &Connection) -> Result<HashMap<i64, Vec<String>>> {
     }
 
     let mut stmt = conn.prepare("SELECT entry_id, field FROM graphql_fields")?;
-    let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+    })?;
 
     let mut out: HashMap<i64, Vec<String>> = HashMap::new();
     for row in rows {
@@ -1015,9 +1017,8 @@ fn insert_graphql_fields(conn: &Connection, entry_id: i64, fields: &[String]) ->
         return Ok(());
     }
 
-    let mut stmt = conn.prepare_cached(
-        "INSERT OR IGNORE INTO graphql_fields (entry_id, field) VALUES (?1, ?2)",
-    )?;
+    let mut stmt = conn
+        .prepare_cached("INSERT OR IGNORE INTO graphql_fields (entry_id, field) VALUES (?1, ?2)")?;
     let mut seen = HashSet::new();
     for field in fields {
         if !seen.insert(field) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,38 +1,41 @@
-mod diff;
 mod analyze;
+mod check;
 mod csv;
+mod diff;
 mod entry_filter;
 mod export;
 mod export_data;
-mod openapi;
 mod fts;
 mod import;
 mod imports;
 mod info;
 mod merge;
+mod openapi;
 #[cfg(feature = "otel")]
 mod otel;
-mod report;
+mod pii;
 mod prune;
 mod query;
-mod pii;
 mod redact;
 #[cfg(feature = "repl")]
 mod repl;
 #[cfg(feature = "replay")]
 mod replay;
-#[cfg(feature = "serve")]
-mod serve;
+mod report;
+mod request;
 mod schema;
 mod search;
+#[cfg(feature = "serve")]
+mod serve;
 mod stats;
 pub mod util;
 #[cfg(feature = "watch")]
 mod watch;
 mod waterfall;
 
-pub use diff::{run_diff, DiffOptions};
 pub use analyze::{run_analyze, AnalyzeOptions};
+pub use check::{run_check, CheckOptions};
+pub use diff::{run_diff, DiffFailOn, DiffOptions};
 pub use entry_filter::EntryFilterOptions;
 pub use export::{run_export, ExportInputFormat, ExportOptions};
 pub use export_data::{run_export_data, DataExportFormat, ExportDataOptions};
@@ -41,22 +44,25 @@ pub use import::{run_import, ImportOptions};
 pub use imports::run_imports;
 pub use info::{run_info, InfoOptions};
 pub use merge::{run_merge, DedupStrategy, MergeOptions};
+pub use openapi::{run_openapi, OpenApiOptions};
 #[cfg(feature = "otel")]
 pub use otel::{run_otel, OtelExportFormat, OtelExportOptions};
-pub use report::{run_report, ReportOptions};
+pub use pii::{run_pii, run_pii_input, run_pii_with_external_paths, PiiOptions};
 pub use prune::{run_prune, run_prune_with_options, PruneOptions};
 pub use query::{run_query, OutputFormat, QueryOptions};
-pub use pii::{run_pii, run_pii_with_external_paths, PiiOptions};
-pub use redact::{run_redact, run_redact_with_external_paths, NameMatchMode, RedactOptions};
+pub use redact::{
+    run_redact, run_redact_input, run_redact_with_external_paths, NameMatchMode, RedactOptions,
+};
 #[cfg(feature = "repl")]
 pub use repl::{run_repl, ReplOptions};
 #[cfg(feature = "replay")]
 pub use replay::{run_replay, ReplayOptions};
-#[cfg(feature = "serve")]
-pub use serve::{run_serve, MatchMode, ServeOptions};
+pub use report::{run_report, ReportOptions};
+pub use request::{run_request_export, RequestExportFormat, RequestExportOptions};
 pub use schema::run_schema;
 pub use search::run_search;
-pub use openapi::{run_openapi, OpenApiOptions};
+#[cfg(feature = "serve")]
+pub use serve::{run_serve, MatchMode, ServeOptions};
 pub use stats::{run_stats, StatsOptions};
 pub use waterfall::{run_waterfall, WaterfallFormat, WaterfallGroupBy, WaterfallOptions};
 #[cfg(feature = "cdp")]

--- a/src/commands/openapi.rs
+++ b/src/commands/openapi.rs
@@ -72,7 +72,11 @@ pub fn run_openapi(database: PathBuf, options: &OpenApiOptions) -> Result<()> {
             continue;
         };
         let path = parsed.path().to_string();
-        let path = if path.is_empty() { "/".to_string() } else { path };
+        let path = if path.is_empty() {
+            "/".to_string()
+        } else {
+            path
+        };
 
         if let Some(server) = server_from_url(&parsed) {
             servers.insert(server);
@@ -147,7 +151,7 @@ pub fn run_openapi(database: PathBuf, options: &OpenApiOptions) -> Result<()> {
     serde_json::to_writer_pretty(&mut writer, &spec)?;
     writer.write_all(b"\n")?;
 
-    if output_path != PathBuf::from("-") {
+    if output_path != std::path::Path::new("-") {
         println!("Exported OpenAPI schema to {}", output_path.display());
     }
 
@@ -598,7 +602,9 @@ fn merge_schema(a: Schema, b: Schema) -> Schema {
                 schema_type: Some("array".to_string()),
                 properties: None,
                 items: match (a.items, b.items) {
-                    (Some(a_items), Some(b_items)) => Some(Box::new(merge_schema(*a_items, *b_items))),
+                    (Some(a_items), Some(b_items)) => {
+                        Some(Box::new(merge_schema(*a_items, *b_items)))
+                    }
                     (Some(items), None) => Some(items),
                     (None, Some(items)) => Some(items),
                     (None, None) => None,

--- a/src/commands/otel.rs
+++ b/src/commands/otel.rs
@@ -65,36 +65,47 @@ pub fn run_otel(database: PathBuf, options: &OtelExportOptions) -> Result<()> {
             let payload = build_json_export(resource_attrs, spans);
             serde_json::to_writer(&mut writer, &payload)?;
             writer.write_all(b"\n")?;
-            if output_path != PathBuf::from("-") {
-                println!("Exported {} spans to {}", payload.span_count(), output_path.display());
+            if output_path != std::path::Path::new("-") {
+                println!(
+                    "Exported {} spans to {}",
+                    payload.span_count(),
+                    output_path.display()
+                );
             }
             if skipped > 0 {
-                eprintln!("Skipped {} entries without a valid start timestamp", skipped);
+                eprintln!(
+                    "Skipped {} entries without a valid start timestamp",
+                    skipped
+                );
             }
             Ok(())
         }
         OtelExportFormat::OtlpHttp => {
-            let endpoint = options
-                .endpoint
-                .as_deref()
-                .ok_or_else(|| HarliteError::InvalidArgs("--endpoint is required for OTLP export".to_string()))?;
+            let endpoint = options.endpoint.as_deref().ok_or_else(|| {
+                HarliteError::InvalidArgs("--endpoint is required for OTLP export".to_string())
+            })?;
             let endpoint = normalize_otlp_http_endpoint(endpoint)?;
             let request = build_otlp_request(resource_attrs, spans);
             send_otlp_http(&endpoint, request)?;
             if skipped > 0 {
-                eprintln!("Skipped {} entries without a valid start timestamp", skipped);
+                eprintln!(
+                    "Skipped {} entries without a valid start timestamp",
+                    skipped
+                );
             }
             Ok(())
         }
         OtelExportFormat::OtlpGrpc => {
-            let endpoint = options
-                .endpoint
-                .as_deref()
-                .ok_or_else(|| HarliteError::InvalidArgs("--endpoint is required for OTLP export".to_string()))?;
+            let endpoint = options.endpoint.as_deref().ok_or_else(|| {
+                HarliteError::InvalidArgs("--endpoint is required for OTLP export".to_string())
+            })?;
             let request = build_otlp_request(resource_attrs, spans);
             send_otlp_grpc(endpoint, request)?;
             if skipped > 0 {
-                eprintln!("Skipped {} entries without a valid start timestamp", skipped);
+                eprintln!(
+                    "Skipped {} entries without a valid start timestamp",
+                    skipped
+                );
             }
             Ok(())
         }
@@ -190,10 +201,7 @@ enum SpanKind {
     Client,
 }
 
-fn build_resource_attributes(
-    service_name: &str,
-    extra: &[String],
-) -> Result<Vec<Attribute>> {
+fn build_resource_attributes(service_name: &str, extra: &[String]) -> Result<Vec<Attribute>> {
     let mut attrs = vec![Attribute {
         key: "service.name".to_string(),
         value: AttrValue::String(service_name.to_string()),
@@ -248,7 +256,7 @@ fn entry_to_spans(entry: &EntryRow, include_phases: bool) -> Option<Vec<SpanReco
         kind: SpanKind::Client,
         start_unix_nano: start_ns,
         end_unix_nano: end_ns,
-        attributes: attributes.drain(..).collect(),
+        attributes: std::mem::take(&mut attributes),
         status,
     });
 
@@ -470,9 +478,7 @@ fn headers_from_json(json: Option<&str>) -> Option<HashMap<String, String>> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
         return None;
     };
-    let Some(obj) = value.as_object() else {
-        return None;
-    };
+    let obj = value.as_object()?;
     let mut map = HashMap::new();
     for (key, value) in obj {
         if let Some(val) = value.as_str() {
@@ -485,10 +491,7 @@ fn headers_from_json(json: Option<&str>) -> Option<HashMap<String, String>> {
 fn request_bounds(entry: &EntryRow, base_ns: u64) -> (u64, u64) {
     let total_ms = normalize_ms(entry.time_ms).unwrap_or_else(|| {
         let ranges = phase_ranges_ms(entry);
-        ranges
-            .last()
-            .map(|phase| phase.end_ms)
-            .unwrap_or(0.0)
+        ranges.last().map(|phase| phase.end_ms).unwrap_or(0.0)
     });
     let total_ns = ms_to_ns(total_ms);
     (base_ns, base_ns.saturating_add(total_ns))
@@ -620,9 +623,8 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 fn normalize_otlp_http_endpoint(endpoint: &str) -> Result<String> {
-    let parsed = Url::parse(endpoint).map_err(|_| {
-        HarliteError::InvalidArgs("--endpoint must be a valid URL".to_string())
-    })?;
+    let parsed = Url::parse(endpoint)
+        .map_err(|_| HarliteError::InvalidArgs("--endpoint must be a valid URL".to_string()))?;
     let trimmed = endpoint.trim_end_matches('/');
     let path = parsed.path().trim_end_matches('/');
     if path.ends_with("/v1/traces") {
@@ -850,8 +852,8 @@ fn build_otlp_request(
                         value: Some(AnyValue {
                             value: Some(match attr.value {
                                 AttrValue::String(value) => any_value::Value::StringValue(value),
-                        AttrValue::Int(value) => any_value::Value::IntValue(value),
-                        AttrValue::Bool(value) => any_value::Value::BoolValue(value),
+                                AttrValue::Int(value) => any_value::Value::IntValue(value),
+                                AttrValue::Bool(value) => any_value::Value::BoolValue(value),
                             }),
                         }),
                     })
@@ -934,9 +936,7 @@ fn send_otlp_grpc(
     rt.block_on(async move {
         let mut client = TraceServiceClient::connect(endpoint)
             .await
-            .map_err(|err| {
-                HarliteError::InvalidArgs(format!("OTLP gRPC connect failed: {err}"))
-            })?;
+            .map_err(|err| HarliteError::InvalidArgs(format!("OTLP gRPC connect failed: {err}")))?;
         client
             .export(request)
             .await

--- a/src/commands/pii.rs
+++ b/src/commands/pii.rs
@@ -2,18 +2,22 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use percent_encoding::percent_decode_str;
 use regex::{NoExpand, Regex};
 use rusqlite::{params, Connection, OptionalExtension};
 use url::Url;
 
 use crate::db::store_blob;
 use crate::error::{HarliteError, Result};
+use crate::har::{Har, QueryParam};
 
 use super::csv::write_csv_field;
 use super::query::OutputFormat;
 use super::util::{
-    canonicalize_path_for_compare, delete_orphaned_blobs, finalize_sensitive_write,
-    prepare_sensitive_write, resolve_database, ExternalPathPolicy, StagedDatabase,
+    canonicalize_path_for_compare, delete_orphaned_blobs, derived_output_path,
+    finalize_sensitive_write, is_sqlite_file, prepare_sensitive_write, resolve_database,
+    write_json_atomic, ExternalPathPolicy, StagedDatabase,
 };
 
 #[derive(Clone, Copy, Debug, serde::Serialize)]
@@ -104,21 +108,51 @@ struct PiiRedactedBlob {
     text: String,
 }
 
+#[derive(Clone)]
+struct PiiTextBlob {
+    text: String,
+    mime_type: Option<String>,
+}
+
 pub fn run_pii(database: Option<PathBuf>, options: &PiiOptions) -> Result<()> {
     run_pii_with_external_paths(database, options, false, None)
 }
 
-/// Scan/redact PII with an explicit policy for externally stored bodies.
-pub fn run_pii_with_external_paths(
-    database: Option<PathBuf>,
+/// Scan or redact either a HAR file or a harlite database. The existing
+/// database-only entry points remain available to library callers.
+pub fn run_pii_input(
+    input: Option<PathBuf>,
     options: &PiiOptions,
     allow_external_paths: bool,
     external_path_root: Option<&Path>,
 ) -> Result<()> {
+    if input.as_deref().is_some_and(is_har_input) {
+        return run_pii_har(input.expect("HAR input"), options);
+    }
+    run_pii_with_external_paths(input, options, allow_external_paths, external_path_root)
+}
+
+fn is_har_input(path: &Path) -> bool {
+    if path == Path::new("-") {
+        return true;
+    }
+    if path.exists() {
+        return !is_sqlite_file(path);
+    }
+    !matches!(
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| extension.to_ascii_lowercase())
+            .as_deref(),
+        Some("db" | "db3" | "sqlite" | "sqlite3")
+    )
+}
+
+fn validate_pii_options(options: &PiiOptions) -> Result<()> {
     if !options.redact {
         if options.output.is_some() {
             return Err(HarliteError::InvalidArgs(
-                "PII output database requires --redact".to_string(),
+                "PII output requires --redact".to_string(),
             ));
         }
         if options.force {
@@ -132,13 +166,506 @@ pub fn run_pii_with_external_paths(
             ));
         }
     }
+    Ok(())
+}
+
+fn run_pii_har(input: PathBuf, options: &PiiOptions) -> Result<()> {
+    validate_pii_options(options)?;
+    let matchers = build_matchers(options)?;
+    if matchers.is_empty() {
+        return Err(HarliteError::InvalidArgs(
+            "No PII patterns provided".to_string(),
+        ));
+    }
+
+    let mut har = crate::har::parse_har_file(&input)?;
+    let findings = scan_har(&mut har, &matchers, options);
+
+    if options.redact && !options.dry_run {
+        let output = options
+            .output
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| derived_output_path(&input, "-pii-redacted", "har"))?;
+        if output == Path::new("-") {
+            return Err(HarliteError::InvalidArgs(
+                "PII redaction output cannot be standard output because findings are written there; use --output <FILE>"
+                    .to_string(),
+            ));
+        }
+        if input != Path::new("-")
+            && canonicalize_path_for_compare(&input)? == canonicalize_path_for_compare(&output)?
+        {
+            return Err(HarliteError::InvalidArgs(
+                "Output HAR must be different from input HAR".to_string(),
+            ));
+        }
+        write_json_atomic(&output, &har, true, options.force)?;
+    }
+
+    write_findings(&findings, options.format)
+}
+
+fn scan_har(har: &mut Har, matchers: &PiiMatchers, options: &PiiOptions) -> Vec<PiiFinding> {
+    let mut findings = Vec::new();
+    for (index, entry) in har.log.entries.iter_mut().enumerate() {
+        let entry_id = index as i64 + 1;
+        let original_url = entry.request.url.clone();
+        append_har_url_findings(
+            &mut findings,
+            entry_id,
+            &original_url,
+            entry.request.query_string.as_deref(),
+            matchers,
+        );
+        if options.redact {
+            if let Some(redacted) = redact_har_url(&original_url, matchers, &options.token) {
+                entry.request.url = redacted;
+            }
+            redact_query_string(
+                entry.request.query_string.as_mut(),
+                matchers,
+                &options.token,
+            );
+        }
+
+        if let Some(post_data) = entry.request.post_data.as_mut() {
+            let form_urlencoded = is_form_urlencoded_mime(post_data.mime_type.as_deref());
+            if let Some(text) = post_data.text.as_mut() {
+                append_findings(
+                    &mut findings,
+                    entry_id,
+                    &original_url,
+                    PiiLocation::RequestBody,
+                    scan_body_text(text, form_urlencoded, matchers),
+                );
+                if options.redact {
+                    if let Some((redacted, _)) =
+                        redact_body_text(text, form_urlencoded, matchers, &options.token)
+                    {
+                        *text = redacted;
+                        if entry.request.body_size.is_some_and(|size| size >= 0) {
+                            entry.request.body_size = Some(text.len() as i64);
+                        }
+                    }
+                }
+            }
+            if let Some(params) = post_data.params.as_mut() {
+                for param in params {
+                    for field in [
+                        Some(&mut param.name),
+                        param.value.as_mut(),
+                        param.file_name.as_mut(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        scan_and_redact_har_field(
+                            &mut findings,
+                            entry_id,
+                            &original_url,
+                            field,
+                            matchers,
+                            options,
+                        );
+                    }
+                }
+            }
+        }
+
+        let response_form_urlencoded =
+            is_form_urlencoded_mime(entry.response.content.mime_type.as_deref());
+        if let Some(text) = entry.response.content.text.as_mut() {
+            let encoded = entry
+                .response
+                .content
+                .encoding
+                .as_deref()
+                .is_some_and(|encoding| encoding.eq_ignore_ascii_case("base64"));
+            let decoded = if encoded {
+                STANDARD
+                    .decode(text.as_bytes())
+                    .ok()
+                    .and_then(|bytes| String::from_utf8(bytes).ok())
+            } else {
+                Some(text.clone())
+            };
+            if let Some(decoded) = decoded {
+                append_findings(
+                    &mut findings,
+                    entry_id,
+                    &original_url,
+                    PiiLocation::ResponseBody,
+                    scan_body_text(&decoded, response_form_urlencoded, matchers),
+                );
+                if options.redact {
+                    if let Some((redacted, _)) = redact_body_text(
+                        &decoded,
+                        response_form_urlencoded,
+                        matchers,
+                        &options.token,
+                    ) {
+                        entry.response.content.size = redacted.len() as i64;
+                        *text = if encoded {
+                            STANDARD.encode(redacted.as_bytes())
+                        } else {
+                            redacted
+                        };
+                    }
+                }
+            }
+        }
+    }
+    findings
+}
+
+fn scan_and_redact_har_field(
+    findings: &mut Vec<PiiFinding>,
+    entry_id: i64,
+    original_url: &str,
+    field: &mut String,
+    matchers: &PiiMatchers,
+    options: &PiiOptions,
+) {
+    append_findings(
+        findings,
+        entry_id,
+        original_url,
+        PiiLocation::RequestBody,
+        scan_text(field, matchers),
+    );
+    if options.redact {
+        if let Some((redacted, _)) = redact_text(field, matchers, &options.token) {
+            *field = redacted;
+        }
+    }
+}
+
+fn append_har_url_findings(
+    findings: &mut Vec<PiiFinding>,
+    entry_id: i64,
+    original_url: &str,
+    query_string: Option<&[QueryParam]>,
+    matchers: &PiiMatchers,
+) {
+    let Ok(parsed) = Url::parse(original_url) else {
+        append_findings(
+            findings,
+            entry_id,
+            original_url,
+            PiiLocation::Url,
+            scan_text(&decode_url_component(original_url), matchers),
+        );
+        if let Some(params) = query_string {
+            for param in params {
+                append_url_component_findings(
+                    findings,
+                    entry_id,
+                    original_url,
+                    &param.name,
+                    matchers,
+                );
+                append_url_component_findings(
+                    findings,
+                    entry_id,
+                    original_url,
+                    &param.value,
+                    matchers,
+                );
+            }
+        }
+        return;
+    };
+
+    let parsed_pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(name, value)| (name.into_owned(), value.into_owned()))
+        .collect();
+    append_findings(
+        findings,
+        entry_id,
+        original_url,
+        PiiLocation::Url,
+        scan_url_base(&parsed, matchers),
+    );
+
+    let mut seen = HashSet::new();
+    for (name, value) in parsed_pairs {
+        seen.insert((name.clone(), value.clone()));
+        append_url_component_findings(findings, entry_id, original_url, &name, matchers);
+        append_url_component_findings(findings, entry_id, original_url, &value, matchers);
+    }
+    if let Some(params) = query_string {
+        for param in params {
+            if seen.insert((param.name.clone(), param.value.clone())) {
+                append_url_component_findings(
+                    findings,
+                    entry_id,
+                    original_url,
+                    &param.name,
+                    matchers,
+                );
+                append_url_component_findings(
+                    findings,
+                    entry_id,
+                    original_url,
+                    &param.value,
+                    matchers,
+                );
+            }
+        }
+    }
+}
+
+fn append_url_component_findings(
+    findings: &mut Vec<PiiFinding>,
+    entry_id: i64,
+    original_url: &str,
+    value: &str,
+    matchers: &PiiMatchers,
+) {
+    append_findings(
+        findings,
+        entry_id,
+        original_url,
+        PiiLocation::Url,
+        scan_text(&decode_url_component(value), matchers),
+    );
+}
+
+fn redact_har_url(original_url: &str, matchers: &PiiMatchers, token: &str) -> Option<String> {
+    let Ok(mut parsed) = Url::parse(original_url) else {
+        let decoded = decode_url_component(original_url);
+        return redact_text(&decoded, matchers, token).map(|(value, _)| value);
+    };
+
+    let pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(name, value)| (name.into_owned(), value.into_owned()))
+        .collect();
+
+    let mut changed = false;
+    let username = decode_url_component(parsed.username());
+    if let Some((redacted, _)) = redact_text(&username, matchers, token) {
+        parsed.set_username(&redacted).ok()?;
+        changed = true;
+    }
+    if let Some(password) = parsed.password().map(decode_url_component) {
+        if let Some((redacted, _)) = redact_text(&password, matchers, token) {
+            parsed.set_password(Some(&redacted)).ok()?;
+            changed = true;
+        }
+    }
+    if let Some(host) = parsed.host_str().map(str::to_string) {
+        if let Some((redacted, _)) = redact_text(&host, matchers, token) {
+            if parsed.set_host(Some(&redacted)).is_err() {
+                parsed.set_host(Some("redacted.invalid")).ok()?;
+            }
+            changed = true;
+        }
+    }
+
+    if let Some(segments) = parsed
+        .path_segments()
+        .map(|segments| segments.map(decode_url_component).collect::<Vec<_>>())
+    {
+        let mut redacted_segments = Vec::with_capacity(segments.len());
+        let mut path_changed = false;
+        for segment in segments {
+            if let Some((redacted, _)) = redact_text(&segment, matchers, token) {
+                redacted_segments.push(redacted);
+                path_changed = true;
+            } else {
+                redacted_segments.push(segment);
+            }
+        }
+        if path_changed {
+            let mut output = parsed.path_segments_mut().ok()?;
+            output.clear();
+            for segment in &redacted_segments {
+                output.push(segment);
+            }
+            drop(output);
+            changed = true;
+        }
+    } else {
+        let path = decode_url_component(parsed.path());
+        if let Some((redacted, _)) = redact_text(&path, matchers, token) {
+            parsed.set_path(&redacted);
+            changed = true;
+        }
+    }
+
+    if let Some(fragment) = parsed.fragment().map(decode_url_component) {
+        if let Some((redacted, _)) = redact_text(&fragment, matchers, token) {
+            parsed.set_fragment(Some(&redacted));
+            changed = true;
+        }
+    }
+
+    let mut redacted_pairs = Vec::with_capacity(pairs.len());
+    let mut query_changed = false;
+    for (name, value) in pairs {
+        let redacted_name =
+            redact_text(&decode_url_component(&name), matchers, token).map(|(value, _)| value);
+        let redacted_value =
+            redact_text(&decode_url_component(&value), matchers, token).map(|(value, _)| value);
+        query_changed |= redacted_name.is_some() || redacted_value.is_some();
+        redacted_pairs.push((
+            redacted_name.unwrap_or(name),
+            redacted_value.unwrap_or(value),
+        ));
+    }
+    changed |= query_changed;
+    if !changed {
+        return None;
+    }
+
+    if query_changed {
+        parsed.set_query(None);
+        let mut query = parsed.query_pairs_mut();
+        for (name, value) in redacted_pairs {
+            query.append_pair(&name, &value);
+        }
+    }
+
+    Some(parsed.into())
+}
+
+fn decode_url_component(value: &str) -> String {
+    percent_decode_str(value).decode_utf8_lossy().into_owned()
+}
+
+fn is_form_urlencoded_mime(mime_type: Option<&str>) -> bool {
+    mime_type
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| {
+            value
+                .trim()
+                .eq_ignore_ascii_case("application/x-www-form-urlencoded")
+        })
+}
+
+fn scan_body_text(text: &str, form_urlencoded: bool, matchers: &PiiMatchers) -> PiiCounts {
+    if !form_urlencoded {
+        return scan_text(text, matchers);
+    }
+
+    let mut counts = PiiCounts::default();
+    for (name, value) in url::form_urlencoded::parse(text.as_bytes()) {
+        counts.add_assign(scan_text(&decode_url_component(&name), matchers));
+        counts.add_assign(scan_text(&decode_url_component(&value), matchers));
+    }
+    counts
+}
+
+fn redact_body_text(
+    text: &str,
+    form_urlencoded: bool,
+    matchers: &PiiMatchers,
+    token: &str,
+) -> Option<(String, u64)> {
+    if !form_urlencoded {
+        return redact_text(text, matchers, token);
+    }
+
+    let mut changed = false;
+    let mut total = 0;
+    let mut pairs = Vec::new();
+    for (name, value) in url::form_urlencoded::parse(text.as_bytes()) {
+        let name = name.into_owned();
+        let value = value.into_owned();
+        let redacted_name = redact_text(&decode_url_component(&name), matchers, token);
+        let redacted_value = redact_text(&decode_url_component(&value), matchers, token);
+        changed |= redacted_name.is_some() || redacted_value.is_some();
+        total += redacted_name.as_ref().map_or(0, |(_, count)| *count);
+        total += redacted_value.as_ref().map_or(0, |(_, count)| *count);
+        pairs.push((
+            redacted_name.map_or(name, |(value, _)| value),
+            redacted_value.map_or(value, |(value, _)| value),
+        ));
+    }
+    if !changed {
+        return None;
+    }
+
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    for (name, value) in pairs {
+        serializer.append_pair(&name, &value);
+    }
+    Some((serializer.finish(), total))
+}
+
+fn scan_url_base(parsed: &Url, matchers: &PiiMatchers) -> PiiCounts {
+    let mut counts = PiiCounts::default();
+    let mut scan_component = |value: &str| {
+        counts.add_assign(scan_text(&decode_url_component(value), matchers));
+    };
+
+    if !parsed.username().is_empty() {
+        scan_component(parsed.username());
+    }
+    if let Some(password) = parsed.password() {
+        scan_component(password);
+    }
+    if let Some(host) = parsed.host_str() {
+        scan_component(host);
+    }
+    if let Some(segments) = parsed.path_segments() {
+        for segment in segments {
+            scan_component(segment);
+        }
+    } else {
+        scan_component(parsed.path());
+    }
+    if let Some(fragment) = parsed.fragment() {
+        scan_component(fragment);
+    }
+    counts
+}
+
+fn redact_query_string(
+    query_string: Option<&mut Vec<QueryParam>>,
+    matchers: &PiiMatchers,
+    token: &str,
+) {
+    let Some(params) = query_string else {
+        return;
+    };
+    for param in params {
+        if let Some((redacted, _)) =
+            redact_text(&decode_url_component(&param.name), matchers, token)
+        {
+            param.name = redacted;
+        }
+        if let Some((redacted, _)) =
+            redact_text(&decode_url_component(&param.value), matchers, token)
+        {
+            param.value = redacted;
+        }
+    }
+}
+
+fn write_findings(findings: &[PiiFinding], format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => write_json(findings),
+        OutputFormat::Csv => write_csv(findings),
+        OutputFormat::Table => write_table(findings),
+    }
+}
+
+/// Scan/redact PII with an explicit policy for externally stored bodies.
+pub fn run_pii_with_external_paths(
+    database: Option<PathBuf>,
+    options: &PiiOptions,
+    allow_external_paths: bool,
+    external_path_root: Option<&Path>,
+) -> Result<()> {
+    validate_pii_options(options)?;
 
     let input_db = resolve_database(database)?;
-    let external_paths = ExternalPathPolicy::new(
-        &input_db,
-        allow_external_paths,
-        external_path_root,
-    )?;
+    let external_paths =
+        ExternalPathPolicy::new(&input_db, allow_external_paths, external_path_root)?;
 
     let matchers = build_matchers(options)?;
     if matchers.is_empty() {
@@ -189,7 +716,7 @@ pub fn run_pii_with_external_paths(
     let work_conn = &conn;
 
     let mut stmt = work_conn.prepare(
-        "SELECT id, url, query_string, request_body_hash, request_body_size, response_body_hash, response_body_size, response_body_hash_raw, response_body_size_raw FROM entries ORDER BY id",
+        "SELECT id, url, host, path, query_string, request_body_hash, request_body_size, response_body_hash, response_body_size, response_body_hash_raw, response_body_size_raw FROM entries ORDER BY id",
     )?;
 
     let rows = stmt.query_map([], |row| {
@@ -198,16 +725,18 @@ pub fn run_pii_with_external_paths(
             row.get::<_, Option<String>>(1)?,
             row.get::<_, Option<String>>(2)?,
             row.get::<_, Option<String>>(3)?,
-            row.get::<_, Option<i64>>(4)?,
+            row.get::<_, Option<String>>(4)?,
             row.get::<_, Option<String>>(5)?,
             row.get::<_, Option<i64>>(6)?,
             row.get::<_, Option<String>>(7)?,
             row.get::<_, Option<i64>>(8)?,
+            row.get::<_, Option<String>>(9)?,
+            row.get::<_, Option<i64>>(10)?,
         ))
     })?;
 
     let mut update = work_conn.prepare(
-        "UPDATE entries SET url=?1, query_string=?2, request_body_hash=?3, request_body_size=?4, response_body_hash=?5, response_body_size=?6, response_body_hash_raw=?7, response_body_size_raw=?8 WHERE id=?9",
+        "UPDATE entries SET url=?1, host=?2, path=?3, query_string=?4, request_body_hash=?5, request_body_size=?6, response_body_hash=?7, response_body_size=?8, response_body_hash_raw=?9, response_body_size_raw=?10 WHERE id=?11",
     )?;
 
     let has_fts: bool = work_conn
@@ -220,7 +749,7 @@ pub fn run_pii_with_external_paths(
         > 0;
 
     let mut findings: Vec<PiiFinding> = Vec::new();
-    let mut text_cache: HashMap<String, Option<String>> = HashMap::new();
+    let mut text_cache: HashMap<String, Option<PiiTextBlob>> = HashMap::new();
     let mut redacted_cache: HashMap<String, Option<PiiRedactedBlob>> = HashMap::new();
     let mut changed_response_hashes: HashSet<String> = HashSet::new();
 
@@ -228,6 +757,8 @@ pub fn run_pii_with_external_paths(
         let (
             entry_id,
             url,
+            host,
+            path,
             query_string,
             req_body_hash,
             req_body_size,
@@ -239,6 +770,8 @@ pub fn run_pii_with_external_paths(
 
         let mut changed = false;
         let mut new_url = url.clone();
+        let mut new_host = host;
+        let mut new_path = path;
         let mut new_query_string = query_string.clone();
         let mut new_req_body_hash = req_body_hash.clone();
         let mut new_req_body_size = req_body_size;
@@ -248,20 +781,20 @@ pub fn run_pii_with_external_paths(
         let mut new_resp_body_size_raw = resp_body_size_raw;
 
         if let Some(url_str) = url.as_deref() {
-            append_findings(
-                &mut findings,
-                entry_id,
-                url_str,
-                PiiLocation::Url,
-                scan_text(url_str, &matchers),
-            );
+            append_har_url_findings(&mut findings, entry_id, url_str, None, &matchers);
 
             if options.redact {
-                if let Some((redacted, _)) = redact_text(url_str, &matchers, &options.token) {
+                if let Some(redacted) = redact_har_url(url_str, &matchers, &options.token) {
                     if redacted != url_str {
                         new_url = Some(redacted.clone());
                         if let Ok(parsed) = Url::parse(&redacted) {
+                            new_host = parsed.host_str().map(str::to_string);
+                            new_path = Some(parsed.path().to_string());
                             new_query_string = parsed.query().map(|q| q.to_string());
+                        } else {
+                            new_host = None;
+                            new_path = None;
+                            new_query_string = None;
                         }
                         changed = true;
                     }
@@ -276,7 +809,11 @@ pub fn run_pii_with_external_paths(
                     entry_id,
                     url.as_deref().unwrap_or_default(),
                     PiiLocation::RequestBody,
-                    scan_text(&text, &matchers),
+                    scan_body_text(
+                        &text.text,
+                        is_form_urlencoded_mime(text.mime_type.as_deref()),
+                        &matchers,
+                    ),
                 );
 
                 if options.redact {
@@ -304,7 +841,11 @@ pub fn run_pii_with_external_paths(
                     entry_id,
                     url.as_deref().unwrap_or_default(),
                     PiiLocation::ResponseBody,
-                    scan_text(&text, &matchers),
+                    scan_body_text(
+                        &text.text,
+                        is_form_urlencoded_mime(text.mime_type.as_deref()),
+                        &matchers,
+                    ),
                 );
 
                 if options.redact {
@@ -351,6 +892,8 @@ pub fn run_pii_with_external_paths(
         if changed && write {
             update.execute(params![
                 new_url,
+                new_host,
+                new_path,
                 new_query_string,
                 new_req_body_hash,
                 new_req_body_size,
@@ -388,11 +931,7 @@ pub fn run_pii_with_external_paths(
         staged.publish()?;
     }
 
-    match options.format {
-        OutputFormat::Json => write_json(&findings),
-        OutputFormat::Csv => write_csv(&findings),
-        OutputFormat::Table => write_table(&findings),
-    }
+    write_findings(&findings, options.format)
 }
 
 fn append_findings(
@@ -425,6 +964,13 @@ struct PiiCounts {
 }
 
 impl PiiCounts {
+    fn add_assign(&mut self, other: Self) {
+        self.email += other.email;
+        self.phone += other.phone;
+        self.ssn += other.ssn;
+        self.credit_card += other.credit_card;
+    }
+
     fn iter(&self) -> Vec<(PiiKind, u64)> {
         vec![
             (PiiKind::Email, self.email),
@@ -532,14 +1078,14 @@ fn redact_credit_cards(text: &str, regexes: &[Regex], token: &str) -> (String, u
 fn load_blob_text(
     conn: &Connection,
     hash: &str,
-    cache: &mut HashMap<String, Option<String>>,
+    cache: &mut HashMap<String, Option<PiiTextBlob>>,
     external_paths: &ExternalPathPolicy,
-) -> Result<Option<String>> {
+) -> Result<Option<PiiTextBlob>> {
     if let Some(existing) = cache.get(hash) {
         return Ok(existing.clone());
     }
 
-    let Some((content, _mime_type)) = load_blob_for_pii(conn, hash, external_paths)? else {
+    let Some((content, mime_type)) = load_blob_for_pii(conn, hash, external_paths)? else {
         cache.insert(hash.to_string(), None);
         return Ok(None);
     };
@@ -552,8 +1098,9 @@ fn load_blob_text(
         }
     };
 
-    cache.insert(hash.to_string(), Some(text.clone()));
-    Ok(Some(text))
+    let blob = PiiTextBlob { text, mime_type };
+    cache.insert(hash.to_string(), Some(blob.clone()));
+    Ok(Some(blob))
 }
 
 fn load_blob_for_pii(
@@ -622,7 +1169,12 @@ fn redact_blob_cached(
         }
     };
 
-    let Some((redacted_text, _)) = redact_text(text, matchers, token) else {
+    let Some((redacted_text, _)) = redact_body_text(
+        text,
+        is_form_urlencoded_mime(mime_type.as_deref()),
+        matchers,
+        token,
+    ) else {
         cache.insert(hash.to_string(), None);
         return Ok(None);
     };
@@ -776,7 +1328,7 @@ fn write_table(rows: &[PiiFinding]) -> Result<()> {
     }
 
     for width in &mut widths {
-        *width = (*width).min(80).max(8);
+        *width = (*width).clamp(8, 80);
     }
 
     let mut out = io::stdout().lock();

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -98,8 +98,7 @@ pub fn run_prune_with_options(
         )?;
 
         for chunk in hashes.chunks(HASH_CHUNK) {
-            let placeholders = std::iter::repeat("?")
-                .take(chunk.len())
+            let placeholders = std::iter::repeat_n("?", chunk.len())
                 .collect::<Vec<_>>()
                 .join(", ");
 
@@ -128,8 +127,7 @@ pub fn run_prune_with_options(
                 continue;
             }
 
-            let orphan_placeholders = std::iter::repeat("?")
-                .take(orphan_hashes.len())
+            let orphan_placeholders = std::iter::repeat_n("?", orphan_hashes.len())
                 .collect::<Vec<_>>()
                 .join(", ");
             let mut orphan_params: Vec<&dyn rusqlite::ToSql> =

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -233,62 +233,6 @@ fn write_json(columns: &[String], rows: &mut rusqlite::Rows<'_>) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{normalize_single_statement, wrap_query};
-    use crate::error::HarliteError;
-    use rusqlite::types::Value;
-
-    #[test]
-    fn normalize_single_statement_allows_semicolons_in_strings() {
-        let sql = "SELECT ';' AS semi, 'a'';''b' AS escaped";
-        assert_eq!(normalize_single_statement(sql).unwrap(), sql);
-    }
-
-    #[test]
-    fn normalize_single_statement_allows_semicolons_in_comments() {
-        let sql = "SELECT 1 -- trailing; comment\n";
-        assert_eq!(normalize_single_statement(sql).unwrap(), sql);
-
-        let block = "SELECT 1 /* block; comment */";
-        assert_eq!(normalize_single_statement(block).unwrap(), block);
-    }
-
-    #[test]
-    fn normalize_single_statement_rejects_multiple_statements() {
-        let err = normalize_single_statement("SELECT 1; SELECT 2").unwrap_err();
-        match err {
-            HarliteError::InvalidArgs(msg) => {
-                assert!(msg.contains("single SQL statement"));
-            }
-            other => panic!("unexpected error: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn wrap_query_adds_limits() {
-        let (sql, params) = wrap_query("SELECT * FROM entries", Some(10), Some(5));
-        assert_eq!(
-            sql,
-            "SELECT * FROM (SELECT * FROM entries) LIMIT ?1 OFFSET ?2"
-        );
-        assert_eq!(
-            params,
-            vec![Value::Integer(10), Value::Integer(5)]
-        );
-    }
-
-    #[test]
-    fn wrap_query_handles_offset_only() {
-        let (sql, params) = wrap_query("SELECT * FROM entries", None, Some(5));
-        assert_eq!(
-            sql,
-            "SELECT * FROM (SELECT * FROM entries) LIMIT -1 OFFSET ?1"
-        );
-        assert_eq!(params, vec![Value::Integer(5)]);
-    }
-}
-
 const TABLE_CELL_MAX_WIDTH: usize = 80;
 const TABLE_CELL_MIN_WIDTH: usize = 32;
 
@@ -298,8 +242,7 @@ fn column_widths(columns: &[String]) -> Vec<usize> {
         .map(|c| {
             c.chars()
                 .count()
-                .max(TABLE_CELL_MIN_WIDTH)
-                .min(TABLE_CELL_MAX_WIDTH)
+                .clamp(TABLE_CELL_MIN_WIDTH, TABLE_CELL_MAX_WIDTH)
         })
         .collect()
 }
@@ -315,9 +258,9 @@ fn write_table(columns: &[String], rows: &mut rusqlite::Rows<'_>, quiet: bool) -
     }
     while let Some(row) = rows.next()? {
         let mut out_fields: Vec<String> = Vec::with_capacity(columns.len());
-        for i in 0..columns.len() {
+        for (i, width) in widths.iter().copied().enumerate().take(columns.len()) {
             let value = value_to_table(row.get_ref(i)?);
-            out_fields.push(truncate(&value, widths[i]));
+            out_fields.push(truncate(&value, width));
         }
         write_table_row(&mut out, out_fields.iter().map(|s| s.as_str()), &widths)?;
     }
@@ -329,8 +272,7 @@ fn write_table_row<'a, I>(out: &mut impl Write, fields: I, widths: &[usize]) -> 
 where
     I: IntoIterator<Item = &'a str>,
 {
-    let mut i = 0usize;
-    for field in fields {
+    for (i, field) in fields.into_iter().enumerate() {
         if i > 0 {
             out.write_all(b" | ")?;
         }
@@ -341,7 +283,6 @@ where
         if field_len < width {
             out.write_all(" ".repeat(width - field_len).as_bytes())?;
         }
-        i += 1;
     }
     out.write_all(b"\n")?;
     Ok(())
@@ -430,4 +371,57 @@ fn truncate(s: &str, max: usize) -> String {
     let mut out = s[..end].to_string();
     out.push_str("...");
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_single_statement, wrap_query};
+    use crate::error::HarliteError;
+    use rusqlite::types::Value;
+
+    #[test]
+    fn normalize_single_statement_allows_semicolons_in_strings() {
+        let sql = "SELECT ';' AS semi, 'a'';''b' AS escaped";
+        assert_eq!(normalize_single_statement(sql).unwrap(), sql);
+    }
+
+    #[test]
+    fn normalize_single_statement_allows_semicolons_in_comments() {
+        let sql = "SELECT 1 -- trailing; comment\n";
+        assert_eq!(normalize_single_statement(sql).unwrap(), sql);
+
+        let block = "SELECT 1 /* block; comment */";
+        assert_eq!(normalize_single_statement(block).unwrap(), block);
+    }
+
+    #[test]
+    fn normalize_single_statement_rejects_multiple_statements() {
+        let err = normalize_single_statement("SELECT 1; SELECT 2").unwrap_err();
+        match err {
+            HarliteError::InvalidArgs(msg) => {
+                assert!(msg.contains("single SQL statement"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrap_query_adds_limits() {
+        let (sql, params) = wrap_query("SELECT * FROM entries", Some(10), Some(5));
+        assert_eq!(
+            sql,
+            "SELECT * FROM (SELECT * FROM entries) LIMIT ?1 OFFSET ?2"
+        );
+        assert_eq!(params, vec![Value::Integer(10), Value::Integer(5)]);
+    }
+
+    #[test]
+    fn wrap_query_handles_offset_only() {
+        let (sql, params) = wrap_query("SELECT * FROM entries", None, Some(5));
+        assert_eq!(
+            sql,
+            "SELECT * FROM (SELECT * FROM entries) LIMIT -1 OFFSET ?1"
+        );
+        assert_eq!(params, vec![Value::Integer(5)]);
+    }
 }

--- a/src/commands/redact.rs
+++ b/src/commands/redact.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::ValueEnum;
 use regex::{NoExpand, Regex, RegexBuilder};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -8,10 +9,12 @@ use url::Url;
 
 use crate::db::store_blob;
 use crate::error::{HarliteError, Result};
+use crate::har::{Cookie, Har, Header, QueryParam};
 
 use super::util::{
-    canonicalize_path_for_compare, delete_orphaned_blobs, finalize_sensitive_write,
-    prepare_sensitive_write, resolve_database, ExternalPathPolicy, StagedDatabase,
+    canonicalize_path_for_compare, delete_orphaned_blobs, derived_output_path,
+    finalize_sensitive_write, is_sqlite_file, prepare_sensitive_write, resolve_database,
+    write_json_atomic, ExternalPathPolicy, StagedDatabase,
 };
 
 #[derive(Clone, Copy, Debug, ValueEnum, serde::Serialize, serde::Deserialize)]
@@ -163,6 +166,47 @@ fn default_cookie_patterns() -> Vec<String> {
     vec!["*".to_string()]
 }
 
+fn build_redaction_matchers(
+    options: &RedactOptions,
+) -> Result<(NameMatcher, NameMatcher, NameMatcher, Vec<Regex>)> {
+    let mut header_patterns = Vec::new();
+    let mut cookie_patterns = Vec::new();
+    let mut query_patterns = Vec::new();
+    if !options.no_defaults && matches!(options.match_mode, NameMatchMode::Wildcard) {
+        header_patterns.extend(default_header_patterns());
+        cookie_patterns.extend(default_cookie_patterns());
+    }
+    header_patterns.extend(options.headers.iter().cloned());
+    cookie_patterns.extend(options.cookies.iter().cloned());
+    query_patterns.extend(options.query_params.iter().cloned());
+
+    let header_matcher = NameMatcher::new(options.match_mode, &header_patterns)?;
+    let cookie_matcher = NameMatcher::new(options.match_mode, &cookie_patterns)?;
+    let query_matcher = NameMatcher::new(options.match_mode, &query_patterns)?;
+    let body_regexes = options
+        .body_regexes
+        .iter()
+        .map(|pattern| Regex::new(pattern))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    if header_matcher.is_empty()
+        && cookie_matcher.is_empty()
+        && query_matcher.is_empty()
+        && body_regexes.is_empty()
+    {
+        let hint = if !matches!(options.match_mode, NameMatchMode::Wildcard) {
+            " (defaults only available in wildcard mode)"
+        } else {
+            ""
+        };
+        return Err(HarliteError::InvalidArgs(format!(
+            "No redaction patterns provided{hint}"
+        )));
+    }
+
+    Ok((header_matcher, cookie_matcher, query_matcher, body_regexes))
+}
+
 fn redact_headers_json(
     json: &str,
     matcher: &NameMatcher,
@@ -249,7 +293,9 @@ fn redact_url_params(
     token: &str,
     matched_names: &mut HashSet<String>,
 ) -> Option<(String, Option<String>, u64)> {
-    let mut parsed = Url::parse(url).ok()?;
+    let Ok(mut parsed) = Url::parse(url) else {
+        return redact_raw_url_params(url, matcher, token, matched_names);
+    };
     let pairs: Vec<(String, String)> = parsed
         .query_pairs()
         .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -281,6 +327,45 @@ fn redact_url_params(
     let new_query = parsed.query().map(|q| q.to_string());
     let new_url: String = parsed.into();
     Some((new_url, new_query, changed))
+}
+
+fn redact_raw_url_params(
+    url: &str,
+    matcher: &NameMatcher,
+    token: &str,
+    matched_names: &mut HashSet<String>,
+) -> Option<(String, Option<String>, u64)> {
+    let (without_fragment, fragment) = url
+        .split_once('#')
+        .map(|(base, fragment)| (base, Some(fragment)))
+        .unwrap_or((url, None));
+    let (prefix, raw_query) = without_fragment.split_once('?')?;
+    let pairs = url::form_urlencoded::parse(raw_query.as_bytes());
+    let mut changed = 0;
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    for (name, value) in pairs {
+        let name = name.into_owned();
+        let mut value = value.into_owned();
+        if matcher.matches(&name) {
+            matched_names.insert(name.clone());
+            if value != token {
+                value = token.to_string();
+                changed += 1;
+            }
+        }
+        serializer.append_pair(&name, &value);
+    }
+    if changed == 0 {
+        return None;
+    }
+
+    let query = serializer.finish();
+    let mut redacted = format!("{prefix}?{query}");
+    if let Some(fragment) = fragment {
+        redacted.push('#');
+        redacted.push_str(fragment);
+    }
+    Some((redacted, Some(query), changed))
 }
 
 #[derive(Clone)]
@@ -419,90 +504,7 @@ fn upsert_response_fts(conn: &Connection, hash: &str, text: &str) -> Result<()> 
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        redact_body_text, redact_cookies_json, redact_headers_json, redact_url_params, NameMatcher,
-        NameMatchMode,
-    };
-    use std::collections::HashSet;
-
-    #[test]
-    fn redacts_headers_with_exact_match() {
-        let matcher = NameMatcher::new(
-            NameMatchMode::Exact,
-            &vec!["authorization".to_string(), "x-api-key".to_string()],
-        )
-        .expect("matcher");
-        let mut matched = HashSet::new();
-        let json = r#"{"Authorization":"secret","x-api-key":"abc","other":"keep"}"#;
-        let (out, count) =
-            redact_headers_json(json, &matcher, "REDACTED", &mut matched).expect("redact");
-
-        assert_eq!(count, 2);
-        assert!(matched.contains("Authorization"));
-        assert!(matched.contains("x-api-key"));
-        let value: serde_json::Value = serde_json::from_str(&out).expect("json");
-        assert_eq!(value.get("Authorization").and_then(|v| v.as_str()), Some("REDACTED"));
-        assert_eq!(value.get("x-api-key").and_then(|v| v.as_str()), Some("REDACTED"));
-        assert_eq!(value.get("other").and_then(|v| v.as_str()), Some("keep"));
-    }
-
-    #[test]
-    fn redacts_cookies_with_wildcard_match() {
-        let matcher =
-            NameMatcher::new(NameMatchMode::Wildcard, &vec!["sess*".to_string()])
-                .expect("matcher");
-        let mut matched = HashSet::new();
-        let json = r#"[{"name":"sessionid","value":"abc"},{"name":"pref","value":"1"}]"#;
-        let (out, count) =
-            redact_cookies_json(json, &matcher, "REDACTED", &mut matched).expect("redact");
-
-        assert_eq!(count, 1);
-        assert!(matched.contains("sessionid"));
-        let value: serde_json::Value = serde_json::from_str(&out).expect("json");
-        let items = value.as_array().expect("array");
-        assert_eq!(
-            items[0].get("value").and_then(|v| v.as_str()),
-            Some("REDACTED")
-        );
-        assert_eq!(items[1].get("value").and_then(|v| v.as_str()), Some("1"));
-    }
-
-    #[test]
-    fn redacts_url_params_and_preserves_query() {
-        let matcher = NameMatcher::new(
-            NameMatchMode::Exact,
-            &vec!["token".to_string(), "secret".to_string()],
-        )
-        .expect("matcher");
-        let mut matched = HashSet::new();
-        let url = "https://example.com/path?token=abc&keep=1&secret=REDACTED";
-        let (new_url, new_query, count) =
-            redact_url_params(url, &matcher, "REDACTED", &mut matched)
-                .expect("should redact");
-
-        assert_eq!(count, 1);
-        assert!(matched.contains("token"));
-        assert!(matched.contains("secret"));
-        assert!(new_url.contains("token=REDACTED"));
-        assert!(new_url.contains("keep=1"));
-        assert!(new_query.unwrap_or_default().contains("secret=REDACTED"));
-    }
-
-    #[test]
-    fn redacts_body_text_with_regexes() {
-        let regexes = vec![regex::Regex::new("secret").expect("regex")];
-        let out = redact_body_text("secret token", &regexes, "REDACTED")
-            .expect("redacted");
-        assert_eq!(out.0, "REDACTED token");
-        assert_eq!(out.1, 1);
-
-        let no_change = redact_body_text("no match", &regexes, "REDACTED");
-        assert!(no_change.is_none());
-    }
-}
-
+#[allow(clippy::too_many_arguments)]
 fn redact_entries(
     conn: &Connection,
     header_matcher: &NameMatcher,
@@ -653,16 +655,15 @@ fn redact_entries(
         }
         if !body_regexes.is_empty() {
             if let Some(hash) = req_body_hash.as_deref() {
-                let (redacted, counted) =
-                    redact_blob_cached(
-                        conn,
-                        hash,
-                        body_regexes,
-                        token,
-                        write,
-                        &mut blob_cache,
-                        external_paths,
-                    )?;
+                let (redacted, counted) = redact_blob_cached(
+                    conn,
+                    hash,
+                    body_regexes,
+                    token,
+                    write,
+                    &mut blob_cache,
+                    external_paths,
+                )?;
                 if let Some(redacted) = redacted {
                     if counted {
                         report.body_matches += redacted.matches;
@@ -676,16 +677,15 @@ fn redact_entries(
                 }
             }
             if let Some(hash) = resp_body_hash.as_deref() {
-                let (redacted, counted) =
-                    redact_blob_cached(
-                        conn,
-                        hash,
-                        body_regexes,
-                        token,
-                        write,
-                        &mut blob_cache,
-                        external_paths,
-                    )?;
+                let (redacted, counted) = redact_blob_cached(
+                    conn,
+                    hash,
+                    body_regexes,
+                    token,
+                    write,
+                    &mut blob_cache,
+                    external_paths,
+                )?;
                 if let Some(redacted) = redacted {
                     if counted {
                         report.body_matches += redacted.matches;
@@ -753,6 +753,321 @@ fn redact_entries(
     Ok(report)
 }
 
+/// Redact either a harlite database or a HAR file. Existing library callers of
+/// `run_redact` retain database-only behavior; the CLI uses this dispatcher.
+pub fn run_redact_input(
+    input: Option<PathBuf>,
+    options: &RedactOptions,
+    allow_external_paths: bool,
+    external_path_root: Option<&Path>,
+) -> Result<()> {
+    if input.as_deref().is_some_and(is_har_input) {
+        return run_redact_har(input.expect("HAR input"), options);
+    }
+    run_redact_with_external_paths(input, options, allow_external_paths, external_path_root)
+}
+
+fn is_har_input(path: &Path) -> bool {
+    if path == Path::new("-") {
+        return true;
+    }
+    if path.exists() {
+        return !is_sqlite_file(path);
+    }
+    !matches!(
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| extension.to_ascii_lowercase())
+            .as_deref(),
+        Some("db" | "db3" | "sqlite" | "sqlite3")
+    )
+}
+
+fn run_redact_har(input: PathBuf, options: &RedactOptions) -> Result<()> {
+    let (header_matcher, cookie_matcher, query_matcher, body_regexes) =
+        build_redaction_matchers(options)?;
+    let mut har = crate::har::parse_har_file(&input)?;
+    let report = redact_har_entries(
+        &mut har,
+        &header_matcher,
+        &cookie_matcher,
+        &query_matcher,
+        &body_regexes,
+        &options.token,
+    );
+
+    if options.dry_run {
+        println!(
+            "Dry run: would redact {} values across {} entries in {} (output not written)",
+            report.total(),
+            report.entries_changed,
+            if input == Path::new("-") {
+                "stdin".to_string()
+            } else {
+                input.display().to_string()
+            }
+        );
+    } else {
+        let output = options
+            .output
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| derived_output_path(&input, "-redacted", "har"))?;
+        if input != Path::new("-")
+            && canonicalize_path_for_compare(&input)? == canonicalize_path_for_compare(&output)?
+        {
+            return Err(HarliteError::InvalidArgs(
+                "Output HAR must be different from input HAR".to_string(),
+            ));
+        }
+        write_json_atomic(&output, &har, true, options.force)?;
+        if output == Path::new("-") {
+            eprintln!(
+                "Redacted {} values across {} entries",
+                report.total(),
+                report.entries_changed
+            );
+            eprint_redaction_breakdown(&report);
+            return Ok(());
+        }
+        println!(
+            "Redacted {} values across {} entries in {}",
+            report.total(),
+            report.entries_changed,
+            output.display()
+        );
+    }
+    print_redaction_breakdown(&report);
+    Ok(())
+}
+
+fn redact_har_entries(
+    har: &mut Har,
+    header_matcher: &NameMatcher,
+    cookie_matcher: &NameMatcher,
+    query_matcher: &NameMatcher,
+    body_regexes: &[Regex],
+    token: &str,
+) -> RedactionReport {
+    let mut report = RedactionReport::default();
+    for entry in &mut har.log.entries {
+        report.entries_scanned += 1;
+        let before = report.total();
+
+        report.request_headers += redact_har_headers(
+            &mut entry.request.headers,
+            header_matcher,
+            token,
+            &mut report.matched_header_names,
+        );
+        report.response_headers += redact_har_headers(
+            &mut entry.response.headers,
+            header_matcher,
+            token,
+            &mut report.matched_header_names,
+        );
+        report.request_cookies += redact_har_cookies(
+            entry.request.cookies.as_mut(),
+            cookie_matcher,
+            token,
+            &mut report.matched_cookie_names,
+        );
+        report.response_cookies += redact_har_cookies(
+            entry.response.cookies.as_mut(),
+            cookie_matcher,
+            token,
+            &mut report.matched_cookie_names,
+        );
+        report.query_params += redact_har_query(
+            &mut entry.request.url,
+            &mut entry.request.query_string,
+            query_matcher,
+            token,
+            &mut report.matched_query_param_names,
+        );
+
+        if let Some(post_data) = entry.request.post_data.as_mut() {
+            let mut body_changed = false;
+            if let Some(text) = post_data.text.as_mut() {
+                if let Some((redacted, matches)) = redact_body_text(text, body_regexes, token) {
+                    *text = redacted;
+                    body_changed = true;
+                    report.body_matches += matches;
+                    if entry.request.body_size.is_some_and(|size| size >= 0) {
+                        entry.request.body_size = Some(text.len() as i64);
+                    }
+                }
+            }
+            if let Some(params) = post_data.params.as_mut() {
+                for param in params {
+                    for field in [
+                        Some(&mut param.name),
+                        param.value.as_mut(),
+                        param.file_name.as_mut(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        let Some((redacted, matches)) =
+                            redact_body_text(field, body_regexes, token)
+                        else {
+                            continue;
+                        };
+                        *field = redacted;
+                        report.body_matches += matches;
+                        body_changed = true;
+                    }
+                }
+            }
+            if body_changed {
+                report.request_bodies += 1;
+            }
+        }
+
+        if let Some(text) = entry.response.content.text.as_mut() {
+            let redacted = if entry
+                .response
+                .content
+                .encoding
+                .as_deref()
+                .is_some_and(|encoding| encoding.eq_ignore_ascii_case("base64"))
+            {
+                STANDARD
+                    .decode(text.as_bytes())
+                    .ok()
+                    .and_then(|bytes| String::from_utf8(bytes).ok())
+                    .and_then(|decoded| {
+                        redact_body_text(&decoded, body_regexes, token).map(
+                            |(redacted, matches)| {
+                                let length = redacted.len() as i64;
+                                (STANDARD.encode(redacted.as_bytes()), matches, length)
+                            },
+                        )
+                    })
+            } else {
+                redact_body_text(text, body_regexes, token).map(|(redacted, matches)| {
+                    let length = redacted.len() as i64;
+                    (redacted, matches, length)
+                })
+            };
+            if let Some((redacted, matches, decoded_length)) = redacted {
+                *text = redacted;
+                entry.response.content.size = decoded_length;
+                report.response_bodies += 1;
+                report.body_matches += matches;
+            }
+        }
+
+        if report.total() > before {
+            report.entries_changed += 1;
+        }
+    }
+    report
+}
+
+fn redact_har_headers(
+    headers: &mut [Header],
+    matcher: &NameMatcher,
+    token: &str,
+    matched_names: &mut HashSet<String>,
+) -> u64 {
+    let mut count = 0;
+    for header in headers {
+        if matcher.matches(&header.name) && header.value != token {
+            header.value = token.to_string();
+            matched_names.insert(header.name.clone());
+            count += 1;
+        }
+    }
+    count
+}
+
+fn redact_har_cookies(
+    cookies: Option<&mut Vec<Cookie>>,
+    matcher: &NameMatcher,
+    token: &str,
+    matched_names: &mut HashSet<String>,
+) -> u64 {
+    let mut count = 0;
+    for cookie in cookies.into_iter().flatten() {
+        if matcher.matches(&cookie.name) && cookie.value != token {
+            cookie.value = token.to_string();
+            matched_names.insert(cookie.name.clone());
+            count += 1;
+        }
+    }
+    count
+}
+
+fn redact_har_query(
+    url: &mut String,
+    query_string: &mut Option<Vec<QueryParam>>,
+    matcher: &NameMatcher,
+    token: &str,
+    matched_names: &mut HashSet<String>,
+) -> u64 {
+    let Some((new_url, new_query, count)) = redact_url_params(url, matcher, token, matched_names)
+    else {
+        return redact_query_list(query_string, matcher, token, matched_names);
+    };
+    *url = new_url;
+    if let Some(query) = new_query {
+        let values: Vec<QueryParam> = url::form_urlencoded::parse(query.as_bytes())
+            .map(|(name, value)| QueryParam {
+                name: name.into_owned(),
+                value: value.into_owned(),
+            })
+            .collect();
+        *query_string = (!values.is_empty()).then_some(values);
+    }
+    count
+}
+
+fn redact_query_list(
+    query_string: &mut Option<Vec<QueryParam>>,
+    matcher: &NameMatcher,
+    token: &str,
+    matched_names: &mut HashSet<String>,
+) -> u64 {
+    let mut count = 0;
+    for param in query_string.iter_mut().flatten() {
+        if matcher.matches(&param.name) && param.value != token {
+            param.value = token.to_string();
+            matched_names.insert(param.name.clone());
+            count += 1;
+        }
+    }
+    count
+}
+
+fn print_redaction_breakdown(report: &RedactionReport) {
+    println!(
+        "Breakdown: request_headers={}, response_headers={}, request_cookies={}, response_cookies={}, query_params={}, request_bodies={}, response_bodies={}, body_matches={}",
+        report.request_headers,
+        report.response_headers,
+        report.request_cookies,
+        report.response_cookies,
+        report.query_params,
+        report.request_bodies,
+        report.response_bodies,
+        report.body_matches
+    );
+}
+
+fn eprint_redaction_breakdown(report: &RedactionReport) {
+    eprintln!(
+        "Breakdown: request_headers={}, response_headers={}, request_cookies={}, response_cookies={}, query_params={}, request_bodies={}, response_bodies={}, body_matches={}",
+        report.request_headers,
+        report.response_headers,
+        report.request_cookies,
+        report.response_cookies,
+        report.query_params,
+        report.request_bodies,
+        report.response_bodies,
+        report.body_matches
+    );
+}
+
 pub fn run_redact(database: Option<PathBuf>, options: &RedactOptions) -> Result<()> {
     run_redact_with_external_paths(database, options, false, None)
 }
@@ -765,49 +1080,11 @@ pub fn run_redact_with_external_paths(
     external_path_root: Option<&Path>,
 ) -> Result<()> {
     let input_db = resolve_database(database)?;
-    let external_paths = ExternalPathPolicy::new(
-        &input_db,
-        allow_external_paths,
-        external_path_root,
-    )?;
+    let external_paths =
+        ExternalPathPolicy::new(&input_db, allow_external_paths, external_path_root)?;
 
-    let mut header_patterns: Vec<String> = Vec::new();
-    let mut cookie_patterns: Vec<String> = Vec::new();
-    let mut query_patterns: Vec<String> = Vec::new();
-    // Only apply defaults when using wildcard mode, since defaults are wildcard patterns
-    if !options.no_defaults && matches!(options.match_mode, NameMatchMode::Wildcard) {
-        header_patterns.extend(default_header_patterns());
-        cookie_patterns.extend(default_cookie_patterns());
-    }
-    header_patterns.extend(options.headers.iter().cloned());
-    cookie_patterns.extend(options.cookies.iter().cloned());
-    query_patterns.extend(options.query_params.iter().cloned());
-
-    let header_matcher = NameMatcher::new(options.match_mode, &header_patterns)?;
-    let cookie_matcher = NameMatcher::new(options.match_mode, &cookie_patterns)?;
-    let query_matcher = NameMatcher::new(options.match_mode, &query_patterns)?;
-
-    let body_regexes: Vec<Regex> = options
-        .body_regexes
-        .iter()
-        .map(|p| Regex::new(p))
-        .collect::<std::result::Result<Vec<_>, _>>()?;
-
-    if header_matcher.is_empty()
-        && cookie_matcher.is_empty()
-        && query_matcher.is_empty()
-        && body_regexes.is_empty()
-    {
-        let hint = if !matches!(options.match_mode, NameMatchMode::Wildcard) {
-            " (defaults only available in wildcard mode)"
-        } else {
-            ""
-        };
-        return Err(HarliteError::InvalidArgs(format!(
-            "No redaction patterns provided{}",
-            hint
-        )));
-    }
+    let (header_matcher, cookie_matcher, query_matcher, body_regexes) =
+        build_redaction_matchers(options)?;
 
     let staged_output = if options.dry_run {
         None
@@ -899,17 +1176,7 @@ pub fn run_redact_with_external_paths(
         );
     }
 
-    println!(
-        "Breakdown: request_headers={}, response_headers={}, request_cookies={}, response_cookies={}, query_params={}, request_bodies={}, response_bodies={}, body_matches={}",
-        report.request_headers,
-        report.response_headers,
-        report.request_cookies,
-        report.response_cookies,
-        report.query_params,
-        report.request_bodies,
-        report.response_bodies,
-        report.body_matches
-    );
+    print_redaction_breakdown(&report);
 
     if !report.matched_header_names.is_empty() {
         let mut names: Vec<String> = report.matched_header_names.into_iter().collect();
@@ -928,4 +1195,91 @@ pub fn run_redact_with_external_paths(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        redact_body_text, redact_cookies_json, redact_headers_json, redact_url_params,
+        NameMatchMode, NameMatcher,
+    };
+    use std::collections::HashSet;
+
+    #[test]
+    fn redacts_headers_with_exact_match() {
+        let matcher = NameMatcher::new(
+            NameMatchMode::Exact,
+            &["authorization".to_string(), "x-api-key".to_string()],
+        )
+        .expect("matcher");
+        let mut matched = HashSet::new();
+        let json = r#"{"Authorization":"secret","x-api-key":"abc","other":"keep"}"#;
+        let (out, count) =
+            redact_headers_json(json, &matcher, "REDACTED", &mut matched).expect("redact");
+
+        assert_eq!(count, 2);
+        assert!(matched.contains("Authorization"));
+        assert!(matched.contains("x-api-key"));
+        let value: serde_json::Value = serde_json::from_str(&out).expect("json");
+        assert_eq!(
+            value.get("Authorization").and_then(|v| v.as_str()),
+            Some("REDACTED")
+        );
+        assert_eq!(
+            value.get("x-api-key").and_then(|v| v.as_str()),
+            Some("REDACTED")
+        );
+        assert_eq!(value.get("other").and_then(|v| v.as_str()), Some("keep"));
+    }
+
+    #[test]
+    fn redacts_cookies_with_wildcard_match() {
+        let matcher =
+            NameMatcher::new(NameMatchMode::Wildcard, &["sess*".to_string()]).expect("matcher");
+        let mut matched = HashSet::new();
+        let json = r#"[{"name":"sessionid","value":"abc"},{"name":"pref","value":"1"}]"#;
+        let (out, count) =
+            redact_cookies_json(json, &matcher, "REDACTED", &mut matched).expect("redact");
+
+        assert_eq!(count, 1);
+        assert!(matched.contains("sessionid"));
+        let value: serde_json::Value = serde_json::from_str(&out).expect("json");
+        let items = value.as_array().expect("array");
+        assert_eq!(
+            items[0].get("value").and_then(|v| v.as_str()),
+            Some("REDACTED")
+        );
+        assert_eq!(items[1].get("value").and_then(|v| v.as_str()), Some("1"));
+    }
+
+    #[test]
+    fn redacts_url_params_and_preserves_query() {
+        let matcher = NameMatcher::new(
+            NameMatchMode::Exact,
+            &["token".to_string(), "secret".to_string()],
+        )
+        .expect("matcher");
+        let mut matched = HashSet::new();
+        let url = "https://example.com/path?token=abc&keep=1&secret=REDACTED";
+        let (new_url, new_query, count) =
+            redact_url_params(url, &matcher, "REDACTED", &mut matched).expect("should redact");
+
+        assert_eq!(count, 1);
+        assert!(matched.contains("token"));
+        assert!(matched.contains("secret"));
+        assert!(new_url.contains("token=REDACTED"));
+        assert!(new_url.contains("keep=1"));
+        assert!(new_query.unwrap_or_default().contains("secret=REDACTED"));
+    }
+
+    #[test]
+    fn redacts_body_text_with_regexes() {
+        let regexes = vec![regex::Regex::new("secret").expect("regex")];
+        let out = redact_body_text("secret token", &regexes, "REDACTED").expect("redacted");
+        assert_eq!(out.0, "REDACTED token");
+        assert_eq!(out.1, 1);
+
+        let no_change = redact_body_text("no match", &regexes, "REDACTED");
+        assert!(no_change.is_none());
+    }
 }

--- a/src/commands/replay.rs
+++ b/src/commands/replay.rs
@@ -188,7 +188,9 @@ pub fn run_replay(input: PathBuf, options: &ReplayOptions) -> Result<()> {
 
 fn resolve_concurrency(configured: usize, total: usize) -> Result<usize> {
     if configured == 0 {
-        let available = thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+        let available = thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
         return Ok(available.max(1).min(total.max(1)));
     }
     Ok(configured.min(total.max(1)))
@@ -228,7 +230,11 @@ fn build_agent(timeout: Option<Duration>) -> ureq::Agent {
     builder.build()
 }
 
-fn replay_entry(agent: &ureq::Agent, entry: ReplayEntry, runtime: &ReplayRuntime) -> (usize, ReplayRow) {
+fn replay_entry(
+    agent: &ureq::Agent,
+    entry: ReplayEntry,
+    runtime: &ReplayRuntime,
+) -> (usize, ReplayRow) {
     let method = entry.method.to_ascii_uppercase();
     let mut row = ReplayRow {
         method: method.clone(),
@@ -400,9 +406,9 @@ fn split_host_port(host: &str) -> Result<(String, Option<u16>)> {
             let host_part = &stripped[..end];
             let rest = &stripped[end + 1..];
             if let Some(port_str) = rest.strip_prefix(':') {
-                let port = port_str.parse::<u16>().map_err(|_| {
-                    HarliteError::InvalidArgs("invalid override port".to_string())
-                })?;
+                let port = port_str
+                    .parse::<u16>()
+                    .map_err(|_| HarliteError::InvalidArgs("invalid override port".to_string()))?;
                 return Ok((host_part.to_string(), Some(port)));
             }
             return Ok((host_part.to_string(), None));
@@ -412,9 +418,9 @@ fn split_host_port(host: &str) -> Result<(String, Option<u16>)> {
     if let Some(idx) = host.rfind(':') {
         let (host_part, port_str) = host.split_at(idx);
         if !host_part.is_empty() {
-            let port = port_str[1..].parse::<u16>().map_err(|_| {
-                HarliteError::InvalidArgs("invalid override port".to_string())
-            })?;
+            let port = port_str[1..]
+                .parse::<u16>()
+                .map_err(|_| HarliteError::InvalidArgs("invalid override port".to_string()))?;
             return Ok((host_part.to_string(), Some(port)));
         }
     }
@@ -467,12 +473,14 @@ fn load_entries_from_db(path: &Path, options: &ReplayOptions) -> Result<Vec<Repl
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
 
-    let mut query = EntryQuery::default();
-    query.hosts = options.host.clone();
-    query.methods = options.method.clone();
-    query.statuses = options.status.clone();
-    query.url_exact = options.url.clone();
-    query.url_contains = options.url_contains.clone();
+    let query = EntryQuery {
+        hosts: options.host.clone(),
+        methods: options.method.clone(),
+        statuses: options.status.clone(),
+        url_exact: options.url.clone(),
+        url_contains: options.url_contains.clone(),
+        ..EntryQuery::default()
+    };
 
     let url_regexes = compile_url_regexes(&options.url_regex)?;
 
@@ -507,11 +515,14 @@ fn load_entries_from_db(path: &Path, options: &ReplayOptions) -> Result<Vec<Repl
         }
     }
 
-    let blob_map: HashMap<String, BlobRow> = blobs.into_iter().map(|b| (b.hash.clone(), b)).collect();
+    let blob_map: HashMap<String, BlobRow> =
+        blobs.into_iter().map(|b| (b.hash.clone(), b)).collect();
 
     let mut out = Vec::new();
     for (idx, row) in rows.into_iter().enumerate() {
-        let Some(url) = row.url.clone() else { continue; };
+        let Some(url) = row.url.clone() else {
+            continue;
+        };
         if !url_regexes.is_empty() && !url_regexes.iter().any(|re| re.is_match(&url)) {
             continue;
         }
@@ -526,7 +537,13 @@ fn load_entries_from_db(path: &Path, options: &ReplayOptions) -> Result<Vec<Repl
             .request_body_hash
             .as_ref()
             .and_then(|hash| blob_map.get(hash))
-            .and_then(|blob| if blob.content.is_empty() { None } else { Some(blob.content.clone()) });
+            .and_then(|blob| {
+                if blob.content.is_empty() {
+                    None
+                } else {
+                    Some(blob.content.clone())
+                }
+            });
 
         out.push(ReplayEntry {
             index: idx,
@@ -562,8 +579,14 @@ fn load_entries_from_har(path: &Path, options: &ReplayOptions) -> Result<Vec<Rep
 
     let mut out = Vec::new();
     for (idx, entry) in har.log.entries.into_iter().enumerate() {
-        if !entry_matches_filters(&entry, options, &url_regexes, &host_set, &method_set, &status_set)
-        {
+        if !entry_matches_filters(
+            &entry,
+            options,
+            &url_regexes,
+            &host_set,
+            &method_set,
+            &status_set,
+        ) {
             continue;
         }
 
@@ -756,11 +779,9 @@ fn compile_rules(options: &ReplayOptions) -> Result<CompiledOverrides> {
 }
 
 fn parse_host_override(raw: &str) -> Result<HostOverrideRule> {
-    let (pattern_raw, host) = raw
-        .split_once('=')
-        .ok_or_else(|| HarliteError::InvalidArgs(
-            "override-host must be '<url-regex>=<host>'".to_string(),
-        ))?;
+    let (pattern_raw, host) = raw.split_once('=').ok_or_else(|| {
+        HarliteError::InvalidArgs("override-host must be '<url-regex>=<host>'".to_string())
+    })?;
     let pattern = compile_override_pattern(pattern_raw)?;
     if host.trim().is_empty() {
         return Err(HarliteError::InvalidArgs(
@@ -774,10 +795,11 @@ fn parse_host_override(raw: &str) -> Result<HostOverrideRule> {
 }
 
 fn parse_header_override(raw: &str) -> Result<HeaderOverrideRule> {
-    let (left, value) = raw.split_once('=')
-        .ok_or_else(|| HarliteError::InvalidArgs(
+    let (left, value) = raw.split_once('=').ok_or_else(|| {
+        HarliteError::InvalidArgs(
             "override-header must be '<url-regex>:<name>=<value>' or '<name>=<value>'".to_string(),
-        ))?;
+        )
+    })?;
 
     let (pattern_raw, name) = match left.rsplit_once(':') {
         Some((pattern, name)) => (pattern, name),
@@ -876,7 +898,7 @@ fn write_table(rows: &[ReplayRow]) -> Result<()> {
     }
 
     for width in &mut widths {
-        *width = (*width).min(80).max(8);
+        *width = (*width).clamp(8, 80);
     }
 
     let mut out = io::stdout().lock();
@@ -960,8 +982,7 @@ fn write_table_row<'a, I>(out: &mut impl Write, fields: I, widths: &[usize]) -> 
 where
     I: IntoIterator<Item = &'a str>,
 {
-    let mut i = 0usize;
-    for field in fields {
+    for (i, field) in fields.into_iter().enumerate() {
         if i > 0 {
             out.write_all(b" | ")?;
         }
@@ -972,7 +993,6 @@ where
         if field_len < width {
             out.write_all(" ".repeat(width - field_len).as_bytes())?;
         }
-        i += 1;
     }
     out.write_all(b"\n")?;
     Ok(())
@@ -998,13 +1018,11 @@ fn truncate(s: &str, max: usize) -> String {
         return "...".to_string();
     }
     let mut end = 0usize;
-    let mut chars_seen = 0usize;
-    for (i, ch) in s.char_indices() {
+    for (chars_seen, (i, ch)) in s.char_indices().enumerate() {
         if chars_seen >= max.saturating_sub(3) {
             break;
         }
         end = i + ch.len_utf8();
-        chars_seen += 1;
     }
     let mut out = s[..end].to_string();
     out.push_str("...");

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -226,26 +226,32 @@ enum InputKind {
 }
 
 fn detect_input_kind(input: &Path) -> Result<InputKind> {
+    if input == Path::new("-") {
+        return Ok(InputKind::Har);
+    }
     let lower = input
         .extension()
         .and_then(|s| s.to_str())
         .unwrap_or("")
         .to_ascii_lowercase();
-    if lower == "db" || input
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase()
-        .ends_with(".db")
+    if lower == "db"
+        || input
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .ends_with(".db")
     {
         return Ok(InputKind::Db);
     }
-    if lower == "har" || lower == "json" || input
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase()
-        .contains(".har")
+    if lower == "har"
+        || lower == "json"
+        || input
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .contains(".har")
     {
         return Ok(InputKind::Har);
     }
@@ -332,7 +338,11 @@ fn normalize_lower(s: &str) -> String {
     s.trim().to_ascii_lowercase()
 }
 
-fn page_matches_filter(page_id: Option<&str>, page_title: Option<&str>, filters: &[String]) -> bool {
+fn page_matches_filter(
+    page_id: Option<&str>,
+    page_title: Option<&str>,
+    filters: &[String],
+) -> bool {
     if filters.is_empty() {
         return true;
     }
@@ -346,7 +356,7 @@ fn page_matches_filter(page_id: Option<&str>, page_title: Option<&str>, filters:
 }
 
 fn is_navigation_entry(entry: &ReportEntry) -> bool {
-    if entry.method.to_ascii_uppercase() != "GET" {
+    if !entry.method.eq_ignore_ascii_case("GET") {
         return false;
     }
     let Some(mime) = entry.mime.as_deref() else {
@@ -373,7 +383,11 @@ fn build_groups(
         return Vec::new();
     }
 
-    entries.sort_by(|a, b| a.started_at_dt.cmp(&b.started_at_dt).then_with(|| a.url.cmp(&b.url)));
+    entries.sort_by(|a, b| {
+        a.started_at_dt
+            .cmp(&b.started_at_dt)
+            .then_with(|| a.url.cmp(&b.url))
+    });
 
     let mut groups: Vec<WaterfallGroup> = Vec::new();
     let mut group_map: HashMap<String, usize> = HashMap::new();
@@ -381,8 +395,11 @@ fn build_groups(
     let mut current_nav: Option<String> = None;
 
     for entry in entries {
-        if !page_matches_filter(entry.page_id.as_deref(), entry.page_title.as_deref(), page_filters)
-        {
+        if !page_matches_filter(
+            entry.page_id.as_deref(),
+            entry.page_title.as_deref(),
+            page_filters,
+        ) {
             continue;
         }
 
@@ -466,7 +483,9 @@ fn entry_to_report_entry_db(
     page_map: &HashMap<(i64, String), PageRow>,
 ) -> Option<ReportEntry> {
     let started_at = row.started_at?;
-    let dt = DateTime::parse_from_rfc3339(&started_at).ok()?.with_timezone(&Utc);
+    let dt = DateTime::parse_from_rfc3339(&started_at)
+        .ok()?
+        .with_timezone(&Utc);
 
     let url = row.url.unwrap_or_default();
     let host = row.host.unwrap_or_else(|| {
@@ -513,7 +532,10 @@ fn entry_to_report_entry_db(
     })
 }
 
-fn entry_to_report_entry_har(entry: HarEntry, page_title_map: &HashMap<String, Option<String>>) -> Option<ReportEntry> {
+fn entry_to_report_entry_har(
+    entry: HarEntry,
+    page_title_map: &HashMap<String, Option<String>>,
+) -> Option<ReportEntry> {
     let dt = DateTime::parse_from_rfc3339(&entry.started_date_time)
         .ok()?
         .with_timezone(&Utc);
@@ -532,15 +554,18 @@ fn entry_to_report_entry_har(entry: HarEntry, page_title_map: &HashMap<String, O
         .flatten();
 
     let t = entry.timings;
-    let timings = t.as_ref().map(|t| TimingsMs {
-        blocked: normalize_ms(t.blocked),
-        dns: normalize_ms(t.dns),
-        connect: normalize_ms(t.connect),
-        ssl: normalize_ms(t.ssl),
-        send: Some(t.send).filter(|v| *v >= 0.0),
-        wait: Some(t.wait).filter(|v| *v >= 0.0),
-        receive: Some(t.receive).filter(|v| *v >= 0.0),
-    }).unwrap_or_default();
+    let timings = t
+        .as_ref()
+        .map(|t| TimingsMs {
+            blocked: normalize_ms(t.blocked),
+            dns: normalize_ms(t.dns),
+            connect: normalize_ms(t.connect),
+            ssl: normalize_ms(t.ssl),
+            send: Some(t.send).filter(|v| *v >= 0.0),
+            wait: Some(t.wait).filter(|v| *v >= 0.0),
+            receive: Some(t.receive).filter(|v| *v >= 0.0),
+        })
+        .unwrap_or_default();
 
     Some(ReportEntry {
         started_at: entry.started_date_time.clone(),
@@ -555,7 +580,8 @@ fn entry_to_report_entry_har(entry: HarEntry, page_title_map: &HashMap<String, O
         status: Some(entry.response.status),
         mime: entry.response.content.mime_type.clone(),
         request_body_size: normalize_i64(entry.request.body_size),
-        response_body_size: normalize_i64(entry.response.body_size).or(Some(entry.response.content.size).filter(|v| *v >= 0)),
+        response_body_size: normalize_i64(entry.response.body_size)
+            .or(Some(entry.response.content.size).filter(|v| *v >= 0)),
         page_id,
         page_title,
     })
@@ -565,7 +591,11 @@ fn apply_start_offsets(entries: &mut [ReportEntry]) -> Option<(DateTime<Utc>, Da
     if entries.is_empty() {
         return None;
     }
-    entries.sort_by(|a, b| a.started_at_dt.cmp(&b.started_at_dt).then_with(|| a.url.cmp(&b.url)));
+    entries.sort_by(|a, b| {
+        a.started_at_dt
+            .cmp(&b.started_at_dt)
+            .then_with(|| a.url.cmp(&b.url))
+    });
     let base = entries.first().map(|e| e.started_at_dt)?;
     let mut max_end = 0.0;
     for e in entries.iter_mut() {
@@ -611,7 +641,11 @@ fn ttfb_ms(entry: &ReportEntry) -> Option<f64> {
 
 fn top_slowest(entries: &[ReportEntry], top: usize) -> (Vec<SlowRow>, Vec<SlowRow>) {
     let mut by_total: Vec<&ReportEntry> = entries.iter().collect();
-    by_total.sort_by(|a, b| b.total_ms.partial_cmp(&a.total_ms).unwrap_or(std::cmp::Ordering::Equal));
+    by_total.sort_by(|a, b| {
+        b.total_ms
+            .partial_cmp(&a.total_ms)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
     let mut by_ttfb: Vec<&ReportEntry> = entries.iter().collect();
     by_ttfb.sort_by(|a, b| {
@@ -630,19 +664,31 @@ fn top_slowest(entries: &[ReportEntry], top: usize) -> (Vec<SlowRow>, Vec<SlowRo
         ttfb_ms: ttfb_ms(e),
     };
 
-    let mut out_total = by_total.into_iter().take(top).map(to_row).collect::<Vec<_>>();
+    let mut out_total = by_total
+        .into_iter()
+        .take(top)
+        .map(to_row)
+        .collect::<Vec<_>>();
     out_total.retain(|r| r.total_ms > 0.0);
 
-    let mut out_ttfb = by_ttfb.into_iter().take(top).map(to_row).collect::<Vec<_>>();
+    let mut out_ttfb = by_ttfb
+        .into_iter()
+        .take(top)
+        .map(to_row)
+        .collect::<Vec<_>>();
     out_ttfb.retain(|r| r.ttfb_ms.unwrap_or(-1.0) >= 0.0);
 
     (out_total, out_ttfb)
 }
 
-fn count_over_threshold(entries: &[ReportEntry], threshold: f64, fetch: fn(&ReportEntry) -> Option<f64>) -> usize {
+fn count_over_threshold(
+    entries: &[ReportEntry],
+    threshold: f64,
+    fetch: fn(&ReportEntry) -> Option<f64>,
+) -> usize {
     entries
         .iter()
-        .filter_map(|e| fetch(e))
+        .filter_map(fetch)
         .filter(|v| *v >= threshold)
         .count()
 }
@@ -675,7 +721,11 @@ fn top_error_endpoints(entries: &[ReportEntry], top: usize) -> Vec<ErrorEndpoint
             sample_url,
         })
         .collect::<Vec<_>>();
-    rows.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.endpoint.cmp(&b.endpoint)));
+    rows.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.endpoint.cmp(&b.endpoint))
+    });
     if rows.len() > top {
         rows.truncate(top);
     }
@@ -709,20 +759,13 @@ fn entry_matches_filters_har(
     if !f.url.is_empty() && !f.url.iter().any(|u| u == &e.url) {
         return false;
     }
-    if !f.url_contains.is_empty()
-        && !f.url_contains.iter().any(|needle| e.url.contains(needle))
-    {
+    if !f.url_contains.is_empty() && !f.url_contains.iter().any(|needle| e.url.contains(needle)) {
         return false;
     }
     if !f.host.is_empty() && !f.host.iter().any(|h| h == &e.host) {
         return false;
     }
-    if !f.method.is_empty()
-        && !f
-            .method
-            .iter()
-            .any(|m| m.eq_ignore_ascii_case(&e.method))
-    {
+    if !f.method.is_empty() && !f.method.iter().any(|m| m.eq_ignore_ascii_case(&e.method)) {
         return false;
     }
     if !f.status.is_empty() && !f.status.iter().any(|s| e.status == Some(*s)) {
@@ -742,7 +785,9 @@ fn entry_matches_filters_har(
         return false;
     }
     if !exts.is_empty() {
-        let Some(ext) = url_extension(&e.url) else { return false };
+        let Some(ext) = url_extension(&e.url) else {
+            return false;
+        };
         if !exts.contains(&ext) {
             return false;
         }
@@ -769,9 +814,7 @@ fn entry_matches_filters_har(
             return false;
         }
     }
-    if !f.source_contains.is_empty()
-        && !f.source_contains.iter().any(|s| source_name.contains(s))
-    {
+    if !f.source_contains.is_empty() && !f.source_contains.iter().any(|s| source_name.contains(s)) {
         return false;
     }
 
@@ -1179,7 +1222,10 @@ fn waterfall_html(report: &JsonReport<'_>) -> String {
             escape_html(&g.name)
         ));
         for e in &g.entries {
-            let status = e.status.map(|v| v.to_string()).unwrap_or_else(|| "-".to_string());
+            let status = e
+                .status
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "-".to_string());
             let x0 = (e.start_ms / total_ms) * W;
             let mut x = x0;
             let mut rects = String::new();
@@ -1243,6 +1289,12 @@ fn waterfall_html(report: &JsonReport<'_>) -> String {
 pub fn run_report(input: PathBuf, options: &ReportOptions) -> Result<()> {
     let kind = detect_input_kind(&input)?;
 
+    if input == Path::new("-") && options.output.is_none() {
+        return Err(HarliteError::InvalidArgs(
+            "Reading a HAR from standard input requires --output".to_string(),
+        ));
+    }
+
     let title = options
         .title
         .clone()
@@ -1304,16 +1356,9 @@ pub fn run_report(input: PathBuf, options: &ReportOptions) -> Result<()> {
                 }
             }
 
-            let from_dt = options
-                .filters
-                .from
-                .as_deref()
-                .and_then(parse_timestamp);
-            let to_dt = options.filters.to.as_deref().and_then(parse_timestamp).map(|dt| {
-                // If user passed a date-only string, parse_timestamp returned midnight.
-                // Accept that behavior (consistent with existing util); users can pass RFC3339 for precision.
-                dt
-            });
+            let from_dt = options.filters.from.as_deref().and_then(parse_timestamp);
+            // Date-only values resolve to midnight; callers can use RFC3339 for precision.
+            let to_dt = options.filters.to.as_deref().and_then(parse_timestamp);
 
             let url_regexes: Vec<Regex> = options
                 .filters
@@ -1333,7 +1378,9 @@ pub fn run_report(input: PathBuf, options: &ReportOptions) -> Result<()> {
 
             let mut entries = Vec::new();
             for e in har.log.entries {
-                let Some(re) = entry_to_report_entry_har(e, &page_title_map) else { continue };
+                let Some(re) = entry_to_report_entry_har(e, &page_title_map) else {
+                    continue;
+                };
                 if !entry_matches_filters_har(
                     &re,
                     options,
@@ -1360,7 +1407,8 @@ pub fn run_report(input: PathBuf, options: &ReportOptions) -> Result<()> {
         total_ms,
     });
 
-    let slow_total_count = count_over_threshold(&entries, options.slow_total_ms, |e| Some(e.total_ms));
+    let slow_total_count =
+        count_over_threshold(&entries, options.slow_total_ms, |e| Some(e.total_ms));
     let slow_ttfb_count = count_over_threshold(&entries, options.slow_ttfb_ms, ttfb_ms);
     let slow = SlowSummary {
         slow_total_threshold_ms: options.slow_total_ms,
@@ -1554,11 +1602,7 @@ mod tests {
         e2.page_id = Some("p2".to_string());
         e2.page_title = Some("Other".to_string());
 
-        let groups = build_groups(
-            vec![e1, e2],
-            WaterfallGroupBy::Page,
-            &["home".to_string()],
-        );
+        let groups = build_groups(vec![e1, e2], WaterfallGroupBy::Page, &["home".to_string()]);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].entries.len(), 1);
         assert_eq!(groups[0].entries[0].page_id.as_deref(), Some("p1"));
@@ -1566,18 +1610,24 @@ mod tests {
 
     #[test]
     fn entry_matches_filters_har_ext_mime_and_size_filters() -> Result<()> {
-        let mut e = entry("2024-01-15T00:00:00.000Z", 0.0, "https://example.com/app.js");
+        let mut e = entry(
+            "2024-01-15T00:00:00.000Z",
+            0.0,
+            "https://example.com/app.js",
+        );
         e.mime = Some("application/json; charset=utf-8".to_string());
         e.request_body_size = Some(100);
         e.response_body_size = Some(200);
 
-        let mut filters = EntryFilterOptions::default();
-        filters.ext = vec!["js".to_string()];
-        filters.mime_contains = vec!["JSON".to_string()];
-        filters.min_request_size = Some("50".to_string());
-        filters.max_request_size = Some("150".to_string());
-        filters.min_response_size = Some("100".to_string());
-        filters.max_response_size = Some("250".to_string());
+        let filters = EntryFilterOptions {
+            ext: vec!["js".to_string()],
+            mime_contains: vec!["JSON".to_string()],
+            min_request_size: Some("50".to_string()),
+            max_request_size: Some("150".to_string()),
+            min_response_size: Some("100".to_string()),
+            max_response_size: Some("250".to_string()),
+            ..EntryFilterOptions::default()
+        };
 
         // Sanity check size parsing; these should all be valid.
         let _ = size::parse_size_bytes_i64(filters.min_request_size.as_deref().unwrap())?;

--- a/src/commands/request.rs
+++ b/src/commands/request.rs
@@ -611,7 +611,7 @@ fn render_fetch(request: &RequestSnapshot, headers: &[&Header]) -> Result<String
             .expect("serialized fetch options object");
         format!(
             "{},\n  \"body\": {body}\n}}",
-            &options_json[..closing].trim_end()
+            options_json[..closing].trim_end()
         )
     } else {
         options_json

--- a/src/commands/request.rs
+++ b/src/commands/request.rs
@@ -1,0 +1,705 @@
+use std::collections::{HashMap, HashSet};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use clap::ValueEnum;
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+use url::Url;
+
+use crate::db::{ensure_schema_upgrades, load_blobs_by_hashes, load_entries, EntryQuery, EntryRow};
+use crate::error::{HarliteError, Result};
+use crate::har::{Cookie, Entry, Header};
+
+use super::util::{is_sqlite_file, write_bytes_atomic, ExternalPathPolicy};
+
+#[derive(Clone, Copy, Debug, Serialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+#[clap(rename_all = "kebab-case")]
+pub enum RequestExportFormat {
+    Curl,
+    Fetch,
+    NodeFetch,
+    #[value(name = "powershell")]
+    PowerShell,
+}
+
+pub struct RequestExportOptions {
+    pub format: RequestExportFormat,
+    pub output: Option<PathBuf>,
+    pub force: bool,
+    pub include_sensitive: bool,
+    pub indexes: Vec<usize>,
+    pub limit: Option<usize>,
+    pub url_contains: Vec<String>,
+    pub host: Vec<String>,
+    pub method: Vec<String>,
+    pub status: Vec<i32>,
+    pub allow_external_paths: bool,
+    pub external_path_root: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+struct RequestSnapshot {
+    method: String,
+    url: String,
+    headers: Vec<Header>,
+    body: Option<Vec<u8>>,
+    body_mime_type: Option<String>,
+    replace_content_type: bool,
+}
+
+#[derive(Clone, Debug)]
+struct CapturedRequestBody {
+    bytes: Vec<u8>,
+    mime_type: Option<String>,
+    replace_content_type: bool,
+}
+
+pub fn run_request_export(input: PathBuf, options: &RequestExportOptions) -> Result<()> {
+    if options.indexes.contains(&0) {
+        return Err(HarliteError::InvalidArgs(
+            "Request indexes are one-based and must be greater than zero".to_string(),
+        ));
+    }
+    let snapshots = if is_sqlite_file(&input) {
+        load_database_requests(&input, options)?
+    } else {
+        load_har_requests(&input, options)?
+    };
+    let selected = select_requests(snapshots, options);
+    if selected.is_empty() {
+        return Err(HarliteError::InvalidArgs(
+            "No requests matched the supplied filters".to_string(),
+        ));
+    }
+
+    let mut rendered = String::new();
+    if matches!(options.format, RequestExportFormat::NodeFetch) {
+        rendered.push_str("import fetch from \"node-fetch\";\n\n");
+    }
+    for (index, request) in selected.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str("\n\n");
+        }
+        rendered.push_str(&render_request(request, options)?);
+    }
+    rendered.push('\n');
+    write_output(
+        options.output.as_deref(),
+        options.force,
+        rendered.as_bytes(),
+    )
+}
+
+fn load_database_requests(
+    path: &Path,
+    options: &RequestExportOptions,
+) -> Result<Vec<RequestSnapshot>> {
+    // Upgrade legacy databases through a writable connection when possible,
+    // then keep request export itself read-only. Current-schema databases on a
+    // read-only filesystem do not need the upgrade connection.
+    if let Ok(upgrade_connection) = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        ensure_schema_upgrades(&upgrade_connection)?;
+    }
+
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let query = EntryQuery {
+        url_contains: options.url_contains.clone(),
+        statuses: options.status.clone(),
+        ..EntryQuery::default()
+    };
+    let rows: Vec<_> = load_entries(&connection, &query)?
+        .into_iter()
+        .filter(|row| database_entry_matches(row, options))
+        .collect();
+    let hashes: Vec<String> = rows
+        .iter()
+        .filter_map(|row| row.request_body_hash.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let policy = ExternalPathPolicy::new(
+        path,
+        options.allow_external_paths,
+        options.external_path_root.as_deref(),
+    )?;
+    let blobs = load_blobs_by_hashes(&connection, &hashes)?;
+    let mut bodies = HashMap::new();
+    for blob in blobs {
+        let mut content = blob.content;
+        if content.is_empty() && blob.size > 0 {
+            if let Some(external_path) = blob.external_path.as_deref() {
+                if let Some(path) = policy.resolve_file(external_path) {
+                    content = std::fs::read(path)?;
+                }
+            }
+        }
+        if !content.is_empty() {
+            bodies.insert(blob.hash, (content, blob.mime_type));
+        }
+    }
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let url = row.url?;
+            let method = row.method.unwrap_or_else(|| "GET".to_string());
+            let mut headers = headers_from_json(row.request_headers.as_deref());
+            if options.include_sensitive {
+                let cookies = cookies_from_json(row.request_cookies.as_deref());
+                append_cookie_header(&mut headers, &cookies);
+            }
+            let body = row
+                .request_body_hash
+                .as_deref()
+                .and_then(|hash| bodies.get(hash).cloned());
+            let (body, body_mime_type) = body
+                .map(|(body, mime_type)| (Some(body), mime_type))
+                .unwrap_or((None, None));
+            Some(RequestSnapshot {
+                method,
+                url,
+                headers,
+                body,
+                body_mime_type,
+                replace_content_type: false,
+            })
+        })
+        .collect())
+}
+
+fn database_entry_matches(row: &EntryRow, options: &RequestExportOptions) -> bool {
+    if !options.host.is_empty() {
+        let host = row
+            .host
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .or_else(|| {
+                row.url.as_deref().and_then(|url| {
+                    Url::parse(url)
+                        .ok()
+                        .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+                })
+            });
+        if host.is_none_or(|host| {
+            !options
+                .host
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(&host))
+        }) {
+            return false;
+        }
+    }
+    options.method.is_empty()
+        || row.method.as_deref().is_some_and(|method| {
+            options
+                .method
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(method))
+        })
+}
+
+fn load_har_requests(path: &Path, options: &RequestExportOptions) -> Result<Vec<RequestSnapshot>> {
+    let har = crate::har::parse_har_file(path)?;
+    Ok(har
+        .log
+        .entries
+        .iter()
+        .filter(|entry| har_entry_matches(entry, options))
+        .map(|entry| {
+            let body = har_request_body(entry);
+            let (body, body_mime_type, replace_content_type) = body
+                .map(|body| (Some(body.bytes), body.mime_type, body.replace_content_type))
+                .unwrap_or((None, None, false));
+            RequestSnapshot {
+                method: entry.request.method.clone(),
+                url: entry.request.url.clone(),
+                headers: request_headers(entry, options.include_sensitive),
+                body,
+                body_mime_type,
+                replace_content_type,
+            }
+        })
+        .collect())
+}
+
+fn append_content_type_header(
+    headers: &mut Vec<Header>,
+    body: Option<&[u8]>,
+    mime: Option<&str>,
+    replace_existing: bool,
+) {
+    if body.is_none() {
+        return;
+    }
+    let Some(mime) = mime.map(str::trim).filter(|mime| !mime.is_empty()) else {
+        return;
+    };
+    if replace_existing {
+        headers.retain(|header| !header.name.eq_ignore_ascii_case("content-type"));
+    } else if headers
+        .iter()
+        .any(|header| header.name.eq_ignore_ascii_case("content-type"))
+    {
+        return;
+    }
+    headers.push(Header {
+        name: "Content-Type".to_string(),
+        value: mime.to_string(),
+    });
+}
+
+fn har_entry_matches(entry: &Entry, options: &RequestExportOptions) -> bool {
+    if !options.url_contains.is_empty()
+        && !options.url_contains.iter().any(|needle| {
+            entry
+                .request
+                .url
+                .to_ascii_lowercase()
+                .contains(&needle.to_ascii_lowercase())
+        })
+    {
+        return false;
+    }
+    if !options.host.is_empty() {
+        let host = Url::parse(&entry.request.url)
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_ascii_lowercase));
+        if host.is_none_or(|host| {
+            !options
+                .host
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(&host))
+        }) {
+            return false;
+        }
+    }
+    if !options.method.is_empty()
+        && !options
+            .method
+            .iter()
+            .any(|method| method.eq_ignore_ascii_case(&entry.request.method))
+    {
+        return false;
+    }
+    options.status.is_empty() || options.status.contains(&entry.response.status)
+}
+
+fn har_request_body(entry: &Entry) -> Option<CapturedRequestBody> {
+    let post_data = entry.request.post_data.as_ref()?;
+    let captured_mime = post_data.mime_type.clone();
+    if let Some(text) = post_data.text.as_deref() {
+        return Some(CapturedRequestBody {
+            bytes: text.as_bytes().to_vec(),
+            mime_type: captured_mime,
+            replace_content_type: false,
+        });
+    }
+    let params = post_data.params.as_ref()?;
+    let mime = captured_mime
+        .as_deref()
+        .unwrap_or_default()
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim();
+    if mime.eq_ignore_ascii_case("application/x-www-form-urlencoded") {
+        let body: String = url::form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(params.iter().map(|param| {
+                (
+                    param.name.as_str(),
+                    param.value.as_deref().unwrap_or_default(),
+                )
+            }))
+            .finish();
+        return Some(CapturedRequestBody {
+            bytes: body.into_bytes(),
+            mime_type: captured_mime,
+            replace_content_type: false,
+        });
+    }
+    if mime.eq_ignore_ascii_case("multipart/form-data") {
+        let boundary = multipart_boundary(params);
+        return Some(CapturedRequestBody {
+            bytes: render_multipart_body(params, &boundary),
+            mime_type: Some(format!("multipart/form-data; boundary={boundary}")),
+            replace_content_type: true,
+        });
+    }
+    None
+}
+
+fn multipart_boundary(params: &[crate::har::PostParam]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for param in params {
+        for value in [
+            Some(param.name.as_str()),
+            param.value.as_deref(),
+            param.file_name.as_deref(),
+            param.content_type.as_deref(),
+        ] {
+            let bytes = value.unwrap_or_default().as_bytes();
+            hasher.update(&bytes.len().to_le_bytes());
+            hasher.update(bytes);
+        }
+    }
+    let hash = hasher.finalize().to_hex();
+    format!("harlite-{}", &hash.as_str()[..24])
+}
+
+fn render_multipart_body(params: &[crate::har::PostParam], boundary: &str) -> Vec<u8> {
+    let mut body = Vec::new();
+    for param in params {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!(
+                "Content-Disposition: form-data; name=\"{}\"",
+                multipart_quoted(&param.name)
+            )
+            .as_bytes(),
+        );
+        if let Some(file_name) = param.file_name.as_deref() {
+            body.extend_from_slice(
+                format!("; filename=\"{}\"", multipart_quoted(file_name)).as_bytes(),
+            );
+        }
+        body.extend_from_slice(b"\r\n");
+        if let Some(content_type) = param
+            .content_type
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty() && !value.contains(['\r', '\n']))
+        {
+            body.extend_from_slice(format!("Content-Type: {content_type}\r\n").as_bytes());
+        }
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(param.value.as_deref().unwrap_or_default().as_bytes());
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    body
+}
+
+fn multipart_quoted(value: &str) -> String {
+    value
+        .replace(['\r', '\n'], " ")
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn headers_from_json(json: Option<&str>) -> Vec<Header> {
+    let Some(json) = json else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Vec::new();
+    };
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+    object
+        .iter()
+        .map(|(name, value)| Header {
+            name: name.clone(),
+            value: value
+                .as_str()
+                .map(str::to_string)
+                .unwrap_or_else(|| value.to_string()),
+        })
+        .collect()
+}
+
+fn cookies_from_json(json: Option<&str>) -> Vec<Cookie> {
+    json.and_then(|value| serde_json::from_str(value).ok())
+        .unwrap_or_default()
+}
+
+fn request_headers(entry: &Entry, include_sensitive: bool) -> Vec<Header> {
+    let mut headers = entry.request.headers.clone();
+    if include_sensitive {
+        append_cookie_header(
+            &mut headers,
+            entry.request.cookies.as_deref().unwrap_or_default(),
+        );
+    }
+    headers
+}
+
+fn append_cookie_header(headers: &mut Vec<Header>, cookies: &[Cookie]) {
+    if cookies.is_empty()
+        || headers
+            .iter()
+            .any(|header| header.name.eq_ignore_ascii_case("cookie"))
+    {
+        return;
+    }
+    let value = cookies
+        .iter()
+        .map(|cookie| format!("{}={}", cookie.name, cookie.value))
+        .collect::<Vec<_>>()
+        .join("; ");
+    headers.push(Header {
+        name: "Cookie".to_string(),
+        value,
+    });
+}
+
+fn select_requests(
+    snapshots: Vec<RequestSnapshot>,
+    options: &RequestExportOptions,
+) -> Vec<RequestSnapshot> {
+    let indexes: HashSet<usize> = options.indexes.iter().copied().collect();
+    snapshots
+        .into_iter()
+        .enumerate()
+        .filter(|(index, _)| indexes.is_empty() || indexes.contains(&(index + 1)))
+        .map(|(_, request)| request)
+        .take(options.limit.unwrap_or(usize::MAX))
+        .collect()
+}
+
+fn render_request(request: &RequestSnapshot, options: &RequestExportOptions) -> Result<String> {
+    let mut snapshot_headers = request.headers.clone();
+    append_content_type_header(
+        &mut snapshot_headers,
+        request.body.as_deref(),
+        request.body_mime_type.as_deref(),
+        request.replace_content_type,
+    );
+    let headers: Vec<&Header> = snapshot_headers
+        .iter()
+        .filter(|header| include_header(&header.name, options.include_sensitive))
+        .collect();
+    match options.format {
+        RequestExportFormat::Curl => Ok(render_curl(request, &headers)),
+        RequestExportFormat::Fetch | RequestExportFormat::NodeFetch => {
+            render_fetch(request, &headers)
+        }
+        RequestExportFormat::PowerShell => Ok(render_powershell(request, &headers)),
+    }
+}
+
+fn include_header(name: &str, include_sensitive: bool) -> bool {
+    let name = name.trim().to_ascii_lowercase();
+    if name.is_empty()
+        || name.starts_with(':')
+        || matches!(
+            name.as_str(),
+            "host"
+                | "content-length"
+                | "connection"
+                | "keep-alive"
+                | "proxy-connection"
+                | "te"
+                | "trailer"
+                | "transfer-encoding"
+                | "upgrade"
+        )
+    {
+        return false;
+    }
+    include_sensitive || !is_sensitive_header_name(&name)
+}
+
+fn is_sensitive_header_name(name: &str) -> bool {
+    if matches!(
+        name,
+        "authorization" | "proxy-authorization" | "cookie" | "set-cookie"
+    ) {
+        return true;
+    }
+
+    let segments: Vec<&str> = name
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if segments.iter().any(|segment| {
+        matches!(
+            *segment,
+            "auth"
+                | "authentication"
+                | "authorization"
+                | "key"
+                | "token"
+                | "secret"
+                | "password"
+                | "credential"
+                | "signature"
+        )
+    }) {
+        return !matches!(name, "idempotency-key" | "sec-websocket-key");
+    }
+
+    name.contains("authorization")
+        || name.contains("apikey")
+        || name.contains("accesskey")
+        || name.contains("privatekey")
+        || name.contains("secretkey")
+        || name.contains("token")
+        || name.contains("secret")
+        || name.contains("password")
+        || name.contains("credential")
+        || name.contains("signature")
+}
+
+fn render_curl(request: &RequestSnapshot, headers: &[&Header]) -> String {
+    let mut command = Vec::new();
+    command.push("curl".to_string());
+    command.push(format!("--request {}", shell_quote(&request.method)));
+    command.push(format!("--url {}", shell_quote(&request.url)));
+    for header in headers {
+        command.push(format!(
+            "--header {}",
+            shell_quote(&format!("{}: {}", header.name, header.value))
+        ));
+    }
+    if let Some(body) = request.body.as_deref() {
+        if !body.contains(&0) {
+            if let Ok(text) = std::str::from_utf8(body) {
+                if text.starts_with('@') {
+                    command.push("--data-binary @-".to_string());
+                    return format!("printf %s {} | {}", shell_quote(text), command.join(" "));
+                }
+                command.push(format!("--data-binary {}", shell_quote(text)));
+                return command.join(" ");
+            }
+        }
+        let encoded = STANDARD.encode(body);
+        command.push("--data-binary @-".to_string());
+        return format!(
+            "printf %s {} | base64 --decode | {}",
+            shell_quote(&encoded),
+            command.join(" ")
+        );
+    }
+    command.join(" ")
+}
+
+fn render_fetch(request: &RequestSnapshot, headers: &[&Header]) -> Result<String> {
+    #[derive(Serialize)]
+    struct FetchOptions<'a> {
+        method: &'a str,
+        headers: Vec<(&'a str, &'a str)>,
+    }
+    let options = FetchOptions {
+        method: &request.method,
+        headers: headers
+            .iter()
+            .map(|header| (header.name.as_str(), header.value.as_str()))
+            .collect(),
+    };
+    let options_json = serde_json::to_string_pretty(&options)?;
+    let options_json = if let Some(body) = request.body.as_deref() {
+        let body = if let Ok(text) = std::str::from_utf8(body) {
+            serde_json::to_string(text)?
+        } else {
+            format!(
+                "Uint8Array.from(atob({}), c => c.charCodeAt(0))",
+                serde_json::to_string(&STANDARD.encode(body))?
+            )
+        };
+        let closing = options_json
+            .rfind('}')
+            .expect("serialized fetch options object");
+        format!(
+            "{},\n  \"body\": {body}\n}}",
+            &options_json[..closing].trim_end()
+        )
+    } else {
+        options_json
+    };
+    Ok(format!(
+        "fetch({}, {})",
+        serde_json::to_string(&request.url)?,
+        options_json
+    ))
+}
+
+fn render_powershell(request: &RequestSnapshot, headers: &[&Header]) -> String {
+    let mut command = format!(
+        "Invoke-WebRequest -Method {} -Uri {}",
+        powershell_quote(&request.method),
+        powershell_quote(&request.url)
+    );
+    if !headers.is_empty() {
+        let mut combined: Vec<(&str, String)> = Vec::new();
+        let mut positions: HashMap<String, usize> = HashMap::new();
+        for header in headers {
+            let normalized = header.name.to_ascii_lowercase();
+            if let Some(index) = positions.get(&normalized).copied() {
+                let separator = if normalized == "cookie" { "; " } else { ", " };
+                combined[index].1.push_str(separator);
+                combined[index].1.push_str(&header.value);
+            } else {
+                positions.insert(normalized, combined.len());
+                combined.push((&header.name, header.value.clone()));
+            }
+        }
+        let values = combined
+            .iter()
+            .map(|(name, value)| {
+                format!("{} = {}", powershell_quote(name), powershell_quote(value))
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        command.push_str(&format!(" -Headers @{{ {values} }}"));
+    }
+    if let Some(body) = request.body.as_deref() {
+        if let Ok(text) = std::str::from_utf8(body) {
+            command.push_str(&format!(" -Body {}", powershell_quote(text)));
+        } else {
+            command.push_str(&format!(
+                " -Body ([Convert]::FromBase64String({}))",
+                powershell_quote(&STANDARD.encode(body))
+            ));
+        }
+    }
+    command
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn write_output(path: Option<&Path>, force: bool, bytes: &[u8]) -> Result<()> {
+    let Some(path) = path else {
+        io::stdout().lock().write_all(bytes)?;
+        return Ok(());
+    };
+    if path == Path::new("-") {
+        io::stdout().lock().write_all(bytes)?;
+        return Ok(());
+    }
+    write_bytes_atomic(path, bytes, force)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{include_header, powershell_quote, shell_quote};
+
+    #[test]
+    fn excludes_sensitive_and_transport_headers_by_default() {
+        assert!(!include_header("Authorization", false));
+        assert!(!include_header("Content-Length", true));
+        assert!(include_header("Accept", false));
+        assert!(include_header("Authorization", true));
+    }
+
+    #[test]
+    fn escapes_shells() {
+        assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+        assert_eq!(powershell_quote("a'b"), "'a''b'");
+    }
+}

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -106,14 +106,12 @@ fn write_table_row<'a, I>(out: &mut impl Write, fields: I, widths: &[usize]) -> 
 where
     I: IntoIterator<Item = &'a str>,
 {
-    let mut i = 0usize;
-    for field in fields {
+    for (i, field) in fields.into_iter().enumerate() {
         if i > 0 {
             out.write_all(b"  ")?;
         }
         let width = widths.get(i).copied().unwrap_or(0);
         write!(out, "{:width$}", field, width = width)?;
-        i += 1;
     }
     out.write_all(b"\n")?;
     Ok(())
@@ -154,9 +152,9 @@ fn write_table(columns: &[&str], rows: &mut rusqlite::Rows<'_>, quiet: bool) -> 
     }
     while let Some(row) = rows.next()? {
         let mut fields: Vec<String> = Vec::with_capacity(columns.len());
-        for i in 0..columns.len() {
+        for (i, width) in widths.iter().copied().enumerate().take(columns.len()) {
             let value = value_to_table(row.get_ref(i)?);
-            fields.push(truncate(&value, widths[i]));
+            fields.push(truncate(&value, width));
         }
         write_table_row(&mut out, fields.iter().map(|s| s.as_str()), &widths)?;
     }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -122,18 +122,10 @@ pub fn run_serve(input: PathBuf, options: &ServeOptions) -> Result<()> {
     let rt = tokio::runtime::Runtime::new()
         .map_err(|err| HarliteError::InvalidArgs(format!("Failed to start runtime: {err}")))?;
 
-    if options.tls_cert.is_some() {
-        let tls_config = load_tls_config(
-            options.tls_cert.as_ref().unwrap(),
-            options.tls_key.as_ref().unwrap(),
-        )?;
+    if let (Some(cert), Some(key)) = (&options.tls_cert, &options.tls_key) {
+        let tls_config = load_tls_config(cert, key)?;
         let tls_acceptor = TlsAcceptor::from(Arc::new(tls_config));
-        rt.block_on(run_tls_server(
-            addr,
-            state,
-            tls_acceptor,
-            shutdown_rx,
-        ))
+        rt.block_on(run_tls_server(addr, state, tls_acceptor, shutdown_rx))
     } else {
         rt.block_on(run_plain_server(addr, state, shutdown_rx))
     }
@@ -249,7 +241,10 @@ async fn handle_request(
 
     match entry {
         Some(entry) => {
-            println!("HIT {} {} -> {} ({})", method, path, entry.status, entry.url);
+            println!(
+                "HIT {} {} -> {} ({})",
+                method, path, entry.status, entry.url
+            );
             Ok(build_response(entry))
         }
         None => {
@@ -305,14 +300,10 @@ fn select_entry<'a>(
     match match_mode {
         MatchMode::Strict => entries
             .iter()
-            .filter(|entry| {
-                entry.method.eq_ignore_ascii_case(method) && entry.url == full_url
-            })
+            .filter(|entry| entry.method.eq_ignore_ascii_case(method) && entry.url == full_url)
             .max_by(|a, b| compare_recency(a, b)),
         MatchMode::Fuzzy => {
-            let Some(req_norm) = normalized else {
-                return None;
-            };
+            let req_norm = normalized?;
 
             let mut best: Option<&ServeEntry> = None;
             let mut best_score = 0usize;
@@ -467,9 +458,14 @@ fn load_entries_from_db(path: &Path, options: &ServeOptions) -> Result<Vec<Serve
 
     let mut out = Vec::new();
     for row in rows {
-        let Some(url) = row.url.clone() else { continue; };
+        let Some(url) = row.url.clone() else {
+            continue;
+        };
         let method = row.method.unwrap_or_else(|| "GET".to_string());
-        let status = row.status.and_then(|s| u16::try_from(s).ok()).unwrap_or(200);
+        let status = row
+            .status
+            .and_then(|s| u16::try_from(s).ok())
+            .unwrap_or(200);
         let headers_map = headers_from_json(row.response_headers.as_deref());
         let mut headers = headers_from_map(&headers_map);
         let has_content_encoding = headers_map
@@ -477,9 +473,13 @@ fn load_entries_from_db(path: &Path, options: &ServeOptions) -> Result<Vec<Serve
             .any(|name| name.eq_ignore_ascii_case("content-encoding"));
 
         let body_hash = if has_content_encoding {
-            row.response_body_hash_raw.clone().or(row.response_body_hash.clone())
+            row.response_body_hash_raw
+                .clone()
+                .or(row.response_body_hash.clone())
         } else {
-            row.response_body_hash.clone().or(row.response_body_hash_raw.clone())
+            row.response_body_hash
+                .clone()
+                .or(row.response_body_hash_raw.clone())
         };
         let body = body_hash
             .as_ref()
@@ -659,11 +659,11 @@ fn is_db_path(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_response, headers_from_list, normalize_url, query_score, select_entry, strip_content_encoding,
-        MatchMode, NormalizedUrl, ServeEntry,
+        build_response, headers_from_list, normalize_url, query_score, select_entry,
+        strip_content_encoding, MatchMode, NormalizedUrl, ServeEntry,
     };
-    use bytes::Bytes;
     use crate::har::Header;
+    use bytes::Bytes;
 
     fn entry(method: &str, url: &str, started_at: Option<&str>) -> ServeEntry {
         ServeEntry {
@@ -687,8 +687,16 @@ mod tests {
     #[test]
     fn fuzzy_match_prefers_query_hits() {
         let entries = vec![
-            entry("GET", "http://example.com/api?foo=1", Some("2024-01-01T00:00:00Z")),
-            entry("GET", "http://example.com/api?foo=2", Some("2024-01-02T00:00:00Z")),
+            entry(
+                "GET",
+                "http://example.com/api?foo=1",
+                Some("2024-01-01T00:00:00Z"),
+            ),
+            entry(
+                "GET",
+                "http://example.com/api?foo=2",
+                Some("2024-01-02T00:00:00Z"),
+            ),
         ];
 
         let req = normalize_url("http://example.com/api?foo=2").unwrap();

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -125,7 +125,7 @@ pub fn run_stats(database: PathBuf, options: &StatsOptions) -> Result<()> {
                 if let Some(expiry) = parse_cert_expiry(&expiry_raw) {
                     if expiry <= cutoff {
                         count += 1;
-                        if earliest.map_or(true, |dt| expiry < dt) {
+                        if earliest.is_none_or(|dt| expiry < dt) {
                             earliest = Some(expiry);
                         }
                     }

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -1,4 +1,5 @@
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -6,6 +7,157 @@ use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use rusqlite::{Connection, DatabaseName, OpenFlags};
 
 use crate::error::{HarliteError, Result};
+
+/// Return whether a path points to a SQLite database by inspecting its magic
+/// header. Standard input (`-`) is never treated as SQLite.
+pub fn is_sqlite_file(path: &Path) -> bool {
+    if path == Path::new("-") {
+        return false;
+    }
+    let Ok(mut file) = File::open(path) else {
+        return false;
+    };
+    let mut header = [0u8; 16];
+    file.read_exact(&mut header).is_ok() && header == *b"SQLite format 3\0"
+}
+
+/// Build a sibling output name such as `capture-redacted.har`.
+pub fn derived_output_path(input: &Path, suffix: &str, extension: &str) -> Result<PathBuf> {
+    if input == Path::new("-") {
+        return Err(HarliteError::InvalidArgs(
+            "Reading from standard input requires --output".to_string(),
+        ));
+    }
+    let parent = input
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let stem = input
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .ok_or_else(|| HarliteError::InvalidArgs("Input path must have a filename".to_string()))?;
+    Ok(parent.join(format!("{stem}{suffix}.{extension}")))
+}
+
+/// Serialize JSON through a same-directory temporary file and publish it with
+/// a rename, so failures never leave a partial output at the destination.
+pub fn write_json_atomic<T: serde::Serialize>(
+    destination: &Path,
+    value: &T,
+    pretty: bool,
+    overwrite: bool,
+) -> Result<()> {
+    if destination == Path::new("-") {
+        let stdout = std::io::stdout();
+        let mut output = stdout.lock();
+        if pretty {
+            serde_json::to_writer_pretty(&mut output, value)?;
+        } else {
+            serde_json::to_writer(&mut output, value)?;
+        }
+        output.write_all(b"\n")?;
+        return Ok(());
+    }
+    write_file_atomic(destination, overwrite, |output| {
+        if pretty {
+            serde_json::to_writer_pretty(&mut *output, value)?;
+        } else {
+            serde_json::to_writer(&mut *output, value)?;
+        }
+        output.write_all(b"\n")?;
+        Ok(())
+    })
+}
+
+/// Write already-rendered bytes through a same-directory temporary file and
+/// atomically publish the completed output.
+pub fn write_bytes_atomic(destination: &Path, bytes: &[u8], overwrite: bool) -> Result<()> {
+    if destination == Path::new("-") {
+        std::io::stdout().lock().write_all(bytes)?;
+        return Ok(());
+    }
+    write_file_atomic(destination, overwrite, |output| {
+        output.write_all(bytes)?;
+        Ok(())
+    })
+}
+
+fn write_file_atomic(
+    destination: &Path,
+    overwrite: bool,
+    write: impl FnOnce(&mut BufWriter<File>) -> Result<()>,
+) -> Result<()> {
+    if destination.exists() && !destination.is_file() {
+        return Err(HarliteError::InvalidArgs(format!(
+            "Output path must be a file: {}",
+            destination.display()
+        )));
+    }
+    if destination.exists() && !overwrite {
+        return Err(HarliteError::InvalidArgs(format!(
+            "Output file already exists: {} (use --force to overwrite)",
+            destination.display()
+        )));
+    }
+
+    let parent = destination
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = destination
+        .file_name()
+        .ok_or_else(|| HarliteError::InvalidArgs("Output path must be a file".to_string()))?
+        .to_string_lossy();
+    let staged_path = unique_sibling(parent, &file_name, "stage")?;
+
+    let write_result = (|| -> Result<()> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&staged_path)?;
+        let mut output = BufWriter::new(file);
+        write(&mut output)?;
+        output.flush()?;
+        output.get_ref().sync_all()?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&staged_path);
+        return Err(error);
+    }
+
+    let backup_path = if destination.exists() {
+        let backup = unique_sibling(parent, &file_name, "backup")?;
+        fs::rename(destination, &backup)?;
+        Some(backup)
+    } else {
+        None
+    };
+    if let Err(error) = fs::rename(&staged_path, destination) {
+        if let Some(backup) = &backup_path {
+            let _ = fs::rename(backup, destination);
+        }
+        let _ = fs::remove_file(&staged_path);
+        return Err(error.into());
+    }
+    if let Some(backup) = backup_path {
+        fs::remove_file(backup)?;
+    }
+    Ok(())
+}
+
+fn unique_sibling(parent: &Path, file_name: &str, kind: &str) -> Result<PathBuf> {
+    loop {
+        let id = NEXT_STAGED_DATABASE_ID.fetch_add(1, Ordering::Relaxed);
+        let candidate = parent.join(format!(
+            ".{file_name}.harlite-{kind}-{}-{id}",
+            std::process::id()
+        ));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+}
 
 /// Controls whether database-supplied blob paths may be accessed.
 ///
@@ -331,9 +483,9 @@ pub fn canonicalize_path_for_compare(path: &Path) -> Result<PathBuf> {
 
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let parent_canon = fs::canonicalize(parent)?;
-    let name = path.file_name().ok_or_else(|| {
-        HarliteError::InvalidArgs("Output path must be a file".to_string())
-    })?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| HarliteError::InvalidArgs("Output path must be a file".to_string()))?;
     Ok(parent_canon.join(name))
 }
 
@@ -597,13 +749,12 @@ mod tests {
         std::fs::write(&inside_file, b"inside").unwrap();
         std::fs::write(&outside_file, b"outside").unwrap();
 
-        let policy = ExternalPathPolicy::new(
-            &root.path().join("test.db"),
-            true,
-            Some(root.path()),
-        )
-        .unwrap();
-        assert_eq!(policy.resolve_file("blob"), Some(inside_file.canonicalize().unwrap()));
+        let policy =
+            ExternalPathPolicy::new(&root.path().join("test.db"), true, Some(root.path())).unwrap();
+        assert_eq!(
+            policy.resolve_file("blob"),
+            Some(inside_file.canonicalize().unwrap())
+        );
         assert!(policy
             .resolve_file(outside_file.to_str().unwrap())
             .is_none());

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -192,7 +192,7 @@ pub fn run_watch(directory: PathBuf, options: &WatchOptions) -> Result<()> {
                 }
             }
 
-            if let Err(err) = run_import(&[canonical.clone()], &import_options) {
+            if let Err(err) = run_import(std::slice::from_ref(&canonical), &import_options) {
                 eprintln!("Import failed for {}: {}", canonical.display(), err);
                 continue;
             }
@@ -354,7 +354,7 @@ fn import_existing_files(
                     continue;
                 }
             }
-            run_import(&[canonical.clone()], import_options)?;
+            run_import(std::slice::from_ref(&canonical), import_options)?;
             imported_files.insert(key, fingerprint);
             if options.post_info {
                 let info_options = InfoOptions {

--- a/src/commands/waterfall.rs
+++ b/src/commands/waterfall.rs
@@ -8,7 +8,9 @@ use chrono::{DateTime, NaiveDate, Utc};
 use rusqlite::Connection;
 use serde::Serialize;
 
-use crate::db::{ensure_schema_upgrades, load_entries, load_pages_for_imports, EntryQuery, PageRow};
+use crate::db::{
+    ensure_schema_upgrades, load_entries, load_pages_for_imports, EntryQuery, PageRow,
+};
 use crate::error::{HarliteError, Result};
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -113,7 +115,7 @@ fn page_matches_filter(
 }
 
 fn is_navigation_entry(entry: &WaterfallEntry) -> bool {
-    if entry.method.to_ascii_uppercase() != "GET" {
+    if !entry.method.eq_ignore_ascii_case("GET") {
         return false;
     }
     let Some(mime) = entry.mime.as_deref() else {
@@ -139,13 +141,18 @@ fn build_bar(offset_ms: f64, duration_ms: f64, total_ms: f64, width: usize) -> S
     let start = start_col.clamp(0, (width - 1) as isize) as usize;
     buf[start] = '|';
     let end = (start as isize + 1 + dur_cols).clamp(0, width as isize) as usize;
-    for idx in (start + 1)..end {
-        buf[idx] = '=';
+    for cell in buf.iter_mut().take(end).skip(start + 1) {
+        *cell = '=';
     }
     buf.into_iter().collect()
 }
 
-fn render_text(groups: &[GroupInfo], total_ms: f64, width: usize, writer: &mut dyn Write) -> Result<()> {
+fn render_text(
+    groups: &[GroupInfo],
+    total_ms: f64,
+    width: usize,
+    writer: &mut dyn Write,
+) -> Result<()> {
     writeln!(
         writer,
         "Range: 0.0ms..{:.1}ms | width={} | groups={}",
@@ -156,7 +163,12 @@ fn render_text(groups: &[GroupInfo], total_ms: f64, width: usize, writer: &mut d
 
     for group in groups {
         writeln!(writer)?;
-        writeln!(writer, "Group: {} (entries={})", group.name, group.entries.len())?;
+        writeln!(
+            writer,
+            "Group: {} (entries={})",
+            group.name,
+            group.entries.len()
+        )?;
         for entry in &group.entries {
             let bar = build_bar(entry.start_ms, entry.duration_ms, total_ms, width);
             let status = entry
@@ -166,12 +178,7 @@ fn render_text(groups: &[GroupInfo], total_ms: f64, width: usize, writer: &mut d
             writeln!(
                 writer,
                 "{:>8.1} {:>8.1} {} {} {} {}",
-                entry.start_ms,
-                entry.duration_ms,
-                bar,
-                entry.method,
-                status,
-                entry.url
+                entry.start_ms, entry.duration_ms, bar, entry.method, status, entry.url
             )?;
         }
     }
@@ -267,10 +274,12 @@ pub fn run_waterfall(database: PathBuf, options: &WaterfallOptions) -> Result<()
         None => None,
     };
 
-    let mut query = EntryQuery::default();
-    query.from_started_at = from_started_at;
-    query.to_started_at = to_started_at;
-    query.hosts = options.host.clone();
+    let query = EntryQuery {
+        from_started_at,
+        to_started_at,
+        hosts: options.host.clone(),
+        ..EntryQuery::default()
+    };
 
     let mut rows = load_entries(&conn, &query)?;
     if rows.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::commands::{
-    DedupStrategy, ExportInputFormat, FtsTokenizer, NameMatchMode, OutputFormat,
+    DedupStrategy, DiffFailOn, ExportInputFormat, FtsTokenizer, NameMatchMode, OutputFormat,
 };
 use crate::db::ExtractBodiesKind;
 use crate::error::{HarliteError, Result};
@@ -170,6 +170,12 @@ pub struct DiffConfig {
     pub method: Option<Vec<String>>,
     pub status: Option<Vec<i32>>,
     pub url_regex: Option<Vec<String>>,
+    pub fail_on: Option<Vec<DiffFailOn>>,
+    pub max_total_regression_ms: Option<f64>,
+    pub max_ttfb_regression_ms: Option<f64>,
+    pub max_response_size_increase: Option<i64>,
+    pub max_new_errors: Option<usize>,
+    pub ignore_query_param: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -214,7 +220,7 @@ pub struct StatsConfig {
     pub cert_expiring_days: Option<u64>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Default)]
 pub struct ResolvedConfig {
     pub import: ResolvedImportConfig,
     pub cdp: ResolvedCdpConfig,
@@ -289,7 +295,7 @@ pub struct ResolvedReplayConfig {
     pub override_header: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Default)]
 pub struct ResolvedExportConfig {
     pub output: Option<PathBuf>,
     pub format: Option<ExportInputFormat>,
@@ -358,6 +364,12 @@ pub struct ResolvedDiffConfig {
     pub method: Vec<String>,
     pub status: Vec<i32>,
     pub url_regex: Vec<String>,
+    pub fail_on: Vec<DiffFailOn>,
+    pub max_total_regression_ms: Option<f64>,
+    pub max_ttfb_regression_ms: Option<f64>,
+    pub max_response_size_increase: Option<i64>,
+    pub max_new_errors: Option<usize>,
+    pub ignore_query_param: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -396,30 +408,10 @@ pub struct ResolvedFtsRebuildConfig {
     pub external_path_root: Option<PathBuf>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Default)]
 pub struct ResolvedStatsConfig {
     pub json: bool,
     pub cert_expiring_days: Option<u64>,
-}
-
-impl Default for ResolvedConfig {
-    fn default() -> Self {
-        Self {
-            import: ResolvedImportConfig::default(),
-            cdp: ResolvedCdpConfig::default(),
-            replay: ResolvedReplayConfig::default(),
-            export: ResolvedExportConfig::default(),
-            redact: ResolvedRedactConfig::default(),
-            pii: ResolvedPiiConfig::default(),
-            diff: ResolvedDiffConfig::default(),
-            merge: ResolvedMergeConfig::default(),
-            query: ResolvedQueryConfig::default(),
-            search: ResolvedSearchConfig::default(),
-            repl: ResolvedReplConfig::default(),
-            fts_rebuild: ResolvedFtsRebuildConfig::default(),
-            stats: ResolvedStatsConfig::default(),
-        }
-    }
 }
 
 impl Default for ResolvedImportConfig {
@@ -487,36 +479,6 @@ impl Default for ResolvedReplayConfig {
     }
 }
 
-impl Default for ResolvedExportConfig {
-    fn default() -> Self {
-        Self {
-            output: None,
-            format: None,
-            bodies: false,
-            bodies_raw: false,
-            allow_external_paths: false,
-            external_path_root: None,
-            compact: false,
-            url: Vec::new(),
-            url_contains: Vec::new(),
-            url_regex: Vec::new(),
-            host: Vec::new(),
-            method: Vec::new(),
-            status: Vec::new(),
-            mime: Vec::new(),
-            ext: Vec::new(),
-            source: Vec::new(),
-            source_contains: Vec::new(),
-            from: None,
-            to: None,
-            min_request_size: None,
-            max_request_size: None,
-            min_response_size: None,
-            max_response_size: None,
-        }
-    }
-}
-
 impl Default for ResolvedRedactConfig {
     fn default() -> Self {
         Self {
@@ -564,6 +526,12 @@ impl Default for ResolvedDiffConfig {
             method: Vec::new(),
             status: Vec::new(),
             url_regex: Vec::new(),
+            fail_on: Vec::new(),
+            max_total_regression_ms: None,
+            max_ttfb_regression_ms: None,
+            max_response_size_increase: None,
+            max_new_errors: None,
+            ignore_query_param: Vec::new(),
         }
     }
 }
@@ -615,15 +583,6 @@ impl Default for ResolvedFtsRebuildConfig {
             max_body_size: "1MB".to_string(),
             allow_external_paths: false,
             external_path_root: None,
-        }
-    }
-}
-
-impl Default for ResolvedStatsConfig {
-    fn default() -> Self {
-        Self {
-            json: false,
-            cert_expiring_days: None,
         }
     }
 }
@@ -997,6 +956,24 @@ impl ResolvedDiffConfig {
         if let Some(value) = cfg.url_regex.clone() {
             self.url_regex = value;
         }
+        if let Some(value) = cfg.fail_on.clone() {
+            self.fail_on = value;
+        }
+        if let Some(value) = cfg.max_total_regression_ms {
+            self.max_total_regression_ms = Some(value);
+        }
+        if let Some(value) = cfg.max_ttfb_regression_ms {
+            self.max_ttfb_regression_ms = Some(value);
+        }
+        if let Some(value) = cfg.max_response_size_increase {
+            self.max_response_size_increase = Some(value);
+        }
+        if let Some(value) = cfg.max_new_errors {
+            self.max_new_errors = Some(value);
+        }
+        if let Some(value) = cfg.ignore_query_param.clone() {
+            self.ignore_query_param = value;
+        }
     }
 }
 
@@ -1245,6 +1222,21 @@ impl DiffConfig {
         merge_opt(&mut self.method, other.method);
         merge_opt(&mut self.status, other.status);
         merge_opt(&mut self.url_regex, other.url_regex);
+        merge_opt(&mut self.fail_on, other.fail_on);
+        merge_opt(
+            &mut self.max_total_regression_ms,
+            other.max_total_regression_ms,
+        );
+        merge_opt(
+            &mut self.max_ttfb_regression_ms,
+            other.max_ttfb_regression_ms,
+        );
+        merge_opt(
+            &mut self.max_response_size_increase,
+            other.max_response_size_increase,
+        );
+        merge_opt(&mut self.max_new_errors, other.max_new_errors);
+        merge_opt(&mut self.ignore_query_param, other.ignore_query_param);
     }
 }
 

--- a/src/db/reader.rs
+++ b/src/db/reader.rs
@@ -155,8 +155,7 @@ fn push_in_clause(
     if values.is_empty() {
         return;
     }
-    let placeholders = std::iter::repeat("?")
-        .take(values.len())
+    let placeholders = std::iter::repeat_n("?", values.len())
         .collect::<Vec<_>>()
         .join(", ");
     clauses.push(format!("{column} IN ({placeholders})"));
@@ -174,8 +173,7 @@ fn push_in_clause_i32(
     if values.is_empty() {
         return;
     }
-    let placeholders = std::iter::repeat("?")
-        .take(values.len())
+    let placeholders = std::iter::repeat_n("?", values.len())
         .collect::<Vec<_>>()
         .join(", ");
     clauses.push(format!("{column} IN ({placeholders})"));
@@ -193,8 +191,7 @@ fn push_in_clause_i64(
     if values.is_empty() {
         return;
     }
-    let placeholders = std::iter::repeat("?")
-        .take(values.len())
+    let placeholders = std::iter::repeat_n("?", values.len())
         .collect::<Vec<_>>()
         .join(", ");
     clauses.push(format!("{column} IN ({placeholders})"));
@@ -213,8 +210,7 @@ fn push_like_any(
         return;
     }
 
-    let joined = std::iter::repeat(predicate)
-        .take(needles.len())
+    let joined = std::iter::repeat_n(predicate, needles.len())
         .collect::<Vec<_>>()
         .join(" OR ");
     clauses.push(format!("({joined})"));
@@ -385,8 +381,7 @@ pub fn load_pages_for_imports(conn: &Connection, import_ids: &[i64]) -> Result<V
         return Ok(Vec::new());
     }
 
-    let placeholders = std::iter::repeat("?")
-        .take(import_ids.len())
+    let placeholders = std::iter::repeat_n("?", import_ids.len())
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -394,11 +389,7 @@ pub fn load_pages_for_imports(conn: &Connection, import_ids: &[i64]) -> Result<V
         "SELECT import_id, id, started_at, title, on_content_load_ms, on_load_ms, page_extensions, page_timings_extensions FROM pages WHERE import_id IN ({placeholders})"
     );
 
-    let params: Vec<Value> = import_ids
-        .iter()
-        .copied()
-        .map(|id| Value::Integer(id))
-        .collect();
+    let params: Vec<Value> = import_ids.iter().copied().map(Value::Integer).collect();
 
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
@@ -445,8 +436,7 @@ pub fn load_blobs_by_hashes(conn: &Connection, hashes: &[String]) -> Result<Vec<
     const CHUNK: usize = 900;
 
     for chunk in hashes.chunks(CHUNK) {
-        let placeholders = std::iter::repeat("?")
-            .take(chunk.len())
+        let placeholders = std::iter::repeat_n("?", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");
         let params: Vec<Value> = chunk.iter().map(|h| Value::Text(h.clone())).collect();

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -406,28 +406,16 @@ pub fn ensure_schema_upgrades(conn: &Connection) -> Result<()> {
         conn.execute("ALTER TABLE entries ADD COLUMN request_id TEXT", [])?;
     }
     if !table_has_column(conn, "entries", "parent_request_id")? {
-        conn.execute(
-            "ALTER TABLE entries ADD COLUMN parent_request_id TEXT",
-            [],
-        )?;
+        conn.execute("ALTER TABLE entries ADD COLUMN parent_request_id TEXT", [])?;
     }
     if !table_has_column(conn, "entries", "initiator_type")? {
-        conn.execute(
-            "ALTER TABLE entries ADD COLUMN initiator_type TEXT",
-            [],
-        )?;
+        conn.execute("ALTER TABLE entries ADD COLUMN initiator_type TEXT", [])?;
     }
     if !table_has_column(conn, "entries", "initiator_url")? {
-        conn.execute(
-            "ALTER TABLE entries ADD COLUMN initiator_url TEXT",
-            [],
-        )?;
+        conn.execute("ALTER TABLE entries ADD COLUMN initiator_url TEXT", [])?;
     }
     if !table_has_column(conn, "entries", "initiator_line")? {
-        conn.execute(
-            "ALTER TABLE entries ADD COLUMN initiator_line INTEGER",
-            [],
-        )?;
+        conn.execute("ALTER TABLE entries ADD COLUMN initiator_line INTEGER", [])?;
     }
     if !table_has_column(conn, "entries", "initiator_column")? {
         conn.execute(
@@ -514,7 +502,6 @@ fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool
         .collect();
     Ok(names.iter().any(|n| n == column))
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/db/writer.rs
+++ b/src/db/writer.rs
@@ -12,22 +12,12 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 /// Summary statistics for an import operation.
+#[derive(Default)]
 pub struct ImportStats {
     pub entries_imported: usize,
     pub entries_skipped: usize,
     pub request: BlobStats,
     pub response: BlobStats,
-}
-
-impl Default for ImportStats {
-    fn default() -> Self {
-        Self {
-            entries_imported: 0,
-            entries_skipped: 0,
-            request: BlobStats::default(),
-            response: BlobStats::default(),
-        }
-    }
 }
 
 impl ImportStats {
@@ -601,28 +591,28 @@ fn tls_details_from_value(value: &Value) -> Option<TlsDetails> {
 }
 
 fn tls_details_from_map(map: &Map<String, Value>) -> TlsDetails {
-    let mut out = TlsDetails::default();
-    out.version = get_string_value(map, &["protocol", "tlsVersion", "version"]);
-    out.cipher_suite = get_string_value(map, &["cipher", "cipherSuite", "cipherSuiteName"]);
-    out.cert_subject = get_string_value(
-        map,
-        &[
-            "subjectName",
-            "subject",
-            "certificateSubject",
-            "certSubject",
-        ],
-    );
-    out.cert_issuer = get_string_value(
-        map,
-        &["issuer", "issuerName", "certificateIssuer", "certIssuer"],
-    );
-    if let Some(value) = get_value(
-        map,
-        &["validTo", "expiry", "expires", "notAfter", "expiresAt"],
-    ) {
-        out.cert_expiry = parse_expiry_value(&value);
-    }
+    let mut out = TlsDetails {
+        version: get_string_value(map, &["protocol", "tlsVersion", "version"]),
+        cipher_suite: get_string_value(map, &["cipher", "cipherSuite", "cipherSuiteName"]),
+        cert_subject: get_string_value(
+            map,
+            &[
+                "subjectName",
+                "subject",
+                "certificateSubject",
+                "certSubject",
+            ],
+        ),
+        cert_issuer: get_string_value(
+            map,
+            &["issuer", "issuerName", "certificateIssuer", "certIssuer"],
+        ),
+        cert_expiry: get_value(
+            map,
+            &["validTo", "expiry", "expires", "notAfter", "expiresAt"],
+        )
+        .and_then(|value| parse_expiry_value(&value)),
+    };
 
     if out.cert_subject.is_none() || out.cert_issuer.is_none() || out.cert_expiry.is_none() {
         if let Some(value) = get_value(map, &["certificate", "cert", "certificates"]) {
@@ -926,13 +916,13 @@ pub fn insert_entry_with_hash(
     let mut ssl_ms = None;
     if let Some(timings) = &entry.timings {
         let normalize = |value: f64| if value >= 0.0 { Some(value) } else { None };
-        blocked_ms = timings.blocked.and_then(|v| normalize(v));
-        dns_ms = timings.dns.and_then(|v| normalize(v));
-        connect_ms = timings.connect.and_then(|v| normalize(v));
+        blocked_ms = timings.blocked.and_then(&normalize);
+        dns_ms = timings.dns.and_then(&normalize);
+        connect_ms = timings.connect.and_then(&normalize);
         send_ms = normalize(timings.send);
         wait_ms = normalize(timings.wait);
         receive_ms = normalize(timings.receive);
-        ssl_ms = timings.ssl.and_then(|v| normalize(v));
+        ssl_ms = timings.ssl.and_then(normalize);
     }
     let tls_details = extract_tls_details(entry);
 
@@ -1277,9 +1267,14 @@ mod tests {
         )
         .expect("insert import");
 
-        let result =
-            insert_entry(&conn, import_id, entry, &options, &EntryRelations::default())
-                .expect("insert entry");
+        let result = insert_entry(
+            &conn,
+            import_id,
+            entry,
+            &options,
+            &EntryRelations::default(),
+        )
+        .expect("insert entry");
         assert!(result.inserted);
         assert_eq!(result.blob_stats.request.created, 0);
         assert_eq!(result.blob_stats.response.created, 1);
@@ -1437,8 +1432,14 @@ mod tests {
         )
         .expect("insert import");
 
-        insert_entry(&conn, import_id, entry, &options, &EntryRelations::default())
-            .expect("insert entry");
+        insert_entry(
+            &conn,
+            import_id,
+            entry,
+            &options,
+            &EntryRelations::default(),
+        )
+        .expect("insert entry");
 
         let (hash, body): (String, Vec<u8>) = conn
             .query_row(
@@ -1508,8 +1509,14 @@ mod tests {
         )
         .expect("insert import");
 
-        insert_entry(&conn, import_id, entry, &options, &EntryRelations::default())
-            .expect("insert entry");
+        insert_entry(
+            &conn,
+            import_id,
+            entry,
+            &options,
+            &EntryRelations::default(),
+        )
+        .expect("insert entry");
 
         let request_body_hash: Option<String> = conn
             .query_row("SELECT request_body_hash FROM entries", [], |r| r.get(0))
@@ -1574,8 +1581,14 @@ mod tests {
         )
         .expect("insert import");
 
-        insert_entry(&conn, import_id, entry, &options, &EntryRelations::default())
-            .expect("insert entry");
+        insert_entry(
+            &conn,
+            import_id,
+            entry,
+            &options,
+            &EntryRelations::default(),
+        )
+        .expect("insert entry");
 
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM blobs", [], |r| r.get(0))
@@ -1645,9 +1658,16 @@ mod tests {
             &InsertEntryOptions::default(),
             &EntryRelations::default(),
         )
-            .expect("insert entry");
+        .expect("insert entry");
 
-        let row: (Option<String>, Option<String>, Option<String>, Option<String>, Option<String>) =
+        type TlsRow = (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let row: TlsRow =
             conn.query_row(
                 "SELECT tls_version, tls_cipher_suite, tls_cert_subject, tls_cert_issuer, tls_cert_expiry FROM entries",
                 [],

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,14 @@ pub enum HarliteError {
     /// Invalid command-line arguments or options.
     #[error("{0}")]
     InvalidArgs(String),
+
+    /// Input validation completed and found one or more issues.
+    #[error("Validation failed with {0} issue(s)")]
+    ValidationFailed(usize),
+
+    /// A user-supplied automation or regression threshold was exceeded.
+    #[error("Threshold exceeded: {0}")]
+    ThresholdExceeded(String),
 }
 
 /// Convenience result type for harlite operations.

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -2,7 +2,9 @@
 use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "graphql")]
-use graphql_parser::query::{parse_query, Definition, OperationDefinition, Selection, SelectionSet};
+use graphql_parser::query::{
+    parse_query, Definition, OperationDefinition, Selection, SelectionSet,
+};
 use serde_json::Value;
 use url::Url;
 
@@ -24,8 +26,12 @@ struct GraphQLPayload {
 
 pub fn extract_graphql_info(entry: &Entry) -> Option<GraphQLInfo> {
     let request = &entry.request;
-    let content_type = header_value(&request.headers, "content-type")
-        .or_else(|| request.post_data.as_ref().and_then(|post| post.mime_type.clone()));
+    let content_type = header_value(&request.headers, "content-type").or_else(|| {
+        request
+            .post_data
+            .as_ref()
+            .and_then(|post| post.mime_type.clone())
+    });
 
     let mut payload = GraphQLPayload::default();
     if is_graphql_content_type(content_type.as_deref()) {
@@ -104,7 +110,9 @@ fn apply_post_data(post_data: &PostData, content_type: Option<&str>, payload: &m
             return;
         }
 
-        if is_json_mime(mime) || text.trim_start().starts_with('{') || text.trim_start().starts_with('[')
+        if is_json_mime(mime)
+            || text.trim_start().starts_with('{')
+            || text.trim_start().starts_with('[')
         {
             apply_json_payload(text, payload);
         }
@@ -171,7 +179,11 @@ fn apply_graphql_json(value: &Value, payload: &mut GraphQLPayload) {
             payload.operation_name = Some(name.to_string());
         }
     }
-    if value.get("extensions").and_then(|ext| ext.get("persistedQuery")).is_some() {
+    if value
+        .get("extensions")
+        .and_then(|ext| ext.get("persistedQuery"))
+        .is_some()
+    {
         payload.detected = true;
     }
     if payload.query.is_some() || payload.operation_name.is_some() {

--- a/src/har/parser.rs
+++ b/src/har/parser.rs
@@ -3,14 +3,14 @@
 use serde::de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::{BufReader, Cursor, Read};
+use std::io::{self, BufReader, Cursor, Read};
 use std::path::Path;
 use std::sync::mpsc;
 use std::thread;
 
-use crate::error::Result;
 #[cfg(not(feature = "compression"))]
 use crate::error::HarliteError;
+use crate::error::Result;
 
 pub type Extensions = serde_json::Map<String, serde_json::Value>;
 
@@ -194,13 +194,50 @@ pub fn parse_har_file(path: &Path) -> Result<Har> {
 
 /// Parse a HAR with an explicit limit on decompressed JSON bytes.
 pub fn parse_har_file_with_limit(path: &Path, max_input_bytes: usize) -> Result<Har> {
-    let mut file = File::open(path)?;
-    let mut prefix = [0u8; 4];
-    let prefix_len = file.read(&mut prefix)?;
-    let prefix_reader = Cursor::new(prefix[..prefix_len].to_vec());
-    let chained = prefix_reader.chain(file);
+    if path == Path::new("-") {
+        let stdin = io::stdin();
+        let mut bytes = Vec::new();
+        LimitedReader::new(stdin.lock(), max_input_bytes).read_to_end(&mut bytes)?;
+        let uncompressed =
+            parse_har_reader_with_limit(Cursor::new(bytes.as_slice()), path, max_input_bytes);
+        if uncompressed.is_ok()
+            || detect_compression(path, &bytes[..bytes.len().min(4)]) == Compression::Gzip
+        {
+            return uncompressed;
+        }
 
-    let reader: Box<dyn Read> = match detect_compression(path, &prefix[..prefix_len]) {
+        // Brotli streams have no fixed magic bytes. For stdin, retry a failed
+        // JSON parse with an explicit Brotli hint while preserving the original
+        // JSON error if neither interpretation is valid.
+        #[cfg(feature = "compression")]
+        if let Ok(har) = parse_har_reader_with_limit(
+            Cursor::new(bytes.as_slice()),
+            Path::new("stdin.har.br"),
+            max_input_bytes,
+        ) {
+            return Ok(har);
+        }
+        return uncompressed;
+    }
+
+    parse_har_reader_with_limit(File::open(path)?, path, max_input_bytes)
+}
+
+/// Parse HAR JSON from an arbitrary reader with an explicit decompressed limit.
+///
+/// `path_hint` is used only for compression detection. Magic bytes are still
+/// honored, so compressed stdin works without a filename extension.
+pub fn parse_har_reader_with_limit<'a, R: Read + 'a>(
+    mut input: R,
+    path_hint: &Path,
+    max_input_bytes: usize,
+) -> Result<Har> {
+    let mut prefix = [0u8; 4];
+    let prefix_len = input.read(&mut prefix)?;
+    let prefix_reader = Cursor::new(prefix[..prefix_len].to_vec());
+    let chained = prefix_reader.chain(input);
+
+    let reader: Box<dyn Read + 'a> = match detect_compression(path_hint, &prefix[..prefix_len]) {
         Compression::Gzip => {
             #[cfg(feature = "compression")]
             {
@@ -242,6 +279,10 @@ pub fn parse_har_file_async(path: &Path) -> Result<Har> {
 
 /// Parse a HAR using a background reader with an explicit decompressed limit.
 pub fn parse_har_file_async_with_limit(path: &Path, max_input_bytes: usize) -> Result<Har> {
+    if path == Path::new("-") {
+        return parse_har_file_with_limit(path, max_input_bytes);
+    }
+
     let mut file = File::open(path)?;
     let mut prefix = [0u8; 4];
     let prefix_len = file.read(&mut prefix)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,17 @@ pub mod graphql;
 pub mod har;
 pub mod plugins;
 pub mod size;
+
+mod cli;
+mod config;
+mod router;
+
+/// Parse command-line arguments and run the harlite CLI.
+///
+/// This is primarily used by the packaged binary. Embedders should prefer the
+/// stable functions and option types exposed through [`crate::api`].
+pub fn run_cli() -> error::Result<()> {
+    use clap::Parser;
+
+    router::run(cli::Cli::parse())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,7 @@
-use clap::Parser;
 use std::process;
 
-mod cli;
-mod commands;
-mod config;
-mod db;
-mod error;
-mod graphql;
-mod har;
-mod plugins;
-mod router;
-mod size;
-use crate::cli::Cli;
-
 fn main() {
-    let cli = Cli::parse();
-
-    let result = crate::router::run(cli);
-
-    if let Err(e) = result {
+    if let Err(e) = harlite::run_cli() {
         eprintln!("Error: {}", e);
         process::exit(1);
     }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -38,7 +38,7 @@ pub struct PluginConfig {
 
 impl PluginConfig {
     fn effective_phase(&self) -> PluginPhase {
-        self.phase.unwrap_or_else(|| match self.kind {
+        self.phase.unwrap_or(match self.kind {
             PluginKind::Exporter => PluginPhase::Export,
             _ => PluginPhase::Import,
         })
@@ -68,11 +68,11 @@ impl PluginSet {
         self.plugins.is_empty()
     }
 
-    fn iter_kind_phase<'a>(
-        &'a self,
+    fn iter_kind_phase(
+        &self,
         kind: PluginKind,
         phase: PluginPhase,
-    ) -> impl Iterator<Item = &'a PluginConfig> {
+    ) -> impl Iterator<Item = &PluginConfig> {
         self.plugins
             .iter()
             .filter(move |plugin| plugin.kind == kind && plugin.matches_phase(phase))
@@ -118,8 +118,7 @@ impl PluginSet {
             }
         }
         for plugin in self.iter_kind_phase(PluginKind::Transform, PluginPhase::Export) {
-            if let Some(next) =
-                run_transform_plugin(plugin, &entry, context, PluginPhase::Export)?
+            if let Some(next) = run_transform_plugin(plugin, &entry, context, PluginPhase::Export)?
             {
                 entry = next;
             }
@@ -127,11 +126,7 @@ impl PluginSet {
         Ok(Some(entry))
     }
 
-    pub fn run_exporters(
-        &self,
-        har: &Har,
-        context: &PluginContext<'_>,
-    ) -> Result<ExporterOutcome> {
+    pub fn run_exporters(&self, har: &Har, context: &PluginContext<'_>) -> Result<ExporterOutcome> {
         let mut ran = false;
         let mut skip_default = false;
         for plugin in self.iter_kind_phase(PluginKind::Exporter, PluginPhase::Export) {
@@ -141,10 +136,7 @@ impl PluginSet {
                 skip_default = true;
             }
         }
-        Ok(ExporterOutcome {
-            ran,
-            skip_default,
-        })
+        Ok(ExporterOutcome { ran, skip_default })
     }
 }
 
@@ -302,10 +294,7 @@ fn run_plugin<T: Serialize, R: for<'de> Deserialize<'de>>(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|err| {
-            HarliteError::InvalidArgs(format!(
-                "Failed to spawn plugin '{}': {}",
-                plugin.name, err
-            ))
+            HarliteError::InvalidArgs(format!("Failed to spawn plugin '{}': {}", plugin.name, err))
         })?;
 
     if let Some(mut stdin) = child.stdin.take() {
@@ -370,11 +359,15 @@ mod tests {
 
     #[test]
     fn explicit_cli_enable_is_required_and_config_can_disable() {
-        assert!(!resolve_plugins(&[config(None)], &["test".to_string()], &[])
-            .unwrap()
-            .is_empty());
-        assert!(resolve_plugins(&[config(Some(false))], &["test".to_string()], &[])
-            .unwrap()
-            .is_empty());
+        assert!(
+            !resolve_plugins(&[config(None)], &["test".to_string()], &[])
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            resolve_plugins(&[config(Some(false))], &["test".to_string()], &[])
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 //! Convenience prelude for common harlite embedding tasks.
 
 pub use crate::api::{
-    parse_har_file, parse_har_file_async, run_export, run_import, run_query, ExportOptions,
-    Har, ImportOptions, OutputFormat, QueryOptions, Result, HarliteError,
+    parse_har_file, parse_har_file_async, run_export, run_import, run_query, ExportOptions, Har,
+    HarliteError, ImportOptions, OutputFormat, QueryOptions, Result,
 };

--- a/src/router.rs
+++ b/src/router.rs
@@ -3,14 +3,13 @@ use clap::CommandFactory;
 
 use crate::cli::{Cli, Commands};
 use crate::commands::{
-    run_analyze, run_diff, run_export, run_export_data, run_fts_rebuild, run_import, run_imports,
-    run_info, run_merge, run_openapi, run_pii, run_pii_with_external_paths, run_prune,
-    run_prune_with_options, run_query, run_redact, run_redact_with_external_paths,
-    run_report,
-    run_schema, run_search, run_stats, run_waterfall, AnalyzeOptions, DiffOptions,
+    run_analyze, run_check, run_diff, run_export, run_export_data, run_fts_rebuild, run_import,
+    run_imports, run_info, run_merge, run_openapi, run_pii_input, run_prune,
+    run_prune_with_options, run_query, run_redact_input, run_report, run_request_export,
+    run_schema, run_search, run_stats, run_waterfall, AnalyzeOptions, CheckOptions, DiffOptions,
     EntryFilterOptions, ExportDataOptions, ExportOptions, ImportOptions, InfoOptions, MergeOptions,
-    OpenApiOptions, PiiOptions, PruneOptions, QueryOptions, RedactOptions, ReportOptions, StatsOptions,
-    WaterfallFormat, WaterfallGroupBy, WaterfallOptions,
+    OpenApiOptions, PiiOptions, PruneOptions, QueryOptions, RedactOptions, ReportOptions,
+    RequestExportOptions, StatsOptions, WaterfallFormat, WaterfallGroupBy, WaterfallOptions,
 };
 #[cfg(feature = "cdp")]
 use crate::commands::{run_cdp, CdpOptions};
@@ -227,6 +226,22 @@ pub fn run(cli: Cli) -> Result<()> {
             Ok(())
         }
 
+        Commands::Check {
+            input,
+            json,
+            strict,
+            allow_external_paths,
+            external_path_root,
+        } => run_check(
+            input,
+            &CheckOptions {
+                json,
+                strict,
+                allow_external_paths,
+                external_path_root,
+            },
+        ),
+
         Commands::Schema { database } => run_schema(database),
 
         Commands::Info {
@@ -283,6 +298,9 @@ pub fn run(cli: Cli) -> Result<()> {
             slow_total_ms,
             slow_ttfb_ms,
             top,
+            max_p95_total_ms,
+            max_p95_ttfb_ms,
+            max_errors,
         } => {
             let options = AnalyzeOptions {
                 json: json.unwrap_or(false),
@@ -294,6 +312,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 slow_total_ms: slow_total_ms.unwrap_or(1000.0),
                 slow_ttfb_ms: slow_ttfb_ms.unwrap_or(500.0),
                 top: top.unwrap_or(10),
+                max_p95_total_ms,
+                max_p95_ttfb_ms,
+                max_errors,
             };
             run_analyze(database, &options)
         }
@@ -412,6 +433,38 @@ pub fn run(cli: Cli) -> Result<()> {
             };
             run_export_data(database, &options)
         }
+
+        Commands::Request {
+            input,
+            format,
+            output,
+            force,
+            include_sensitive,
+            index,
+            limit,
+            url_contains,
+            host,
+            method,
+            status,
+            allow_external_paths,
+            external_path_root,
+        } => run_request_export(
+            input,
+            &RequestExportOptions {
+                format,
+                output,
+                force,
+                include_sensitive,
+                indexes: index.unwrap_or_default(),
+                limit,
+                url_contains: url_contains.unwrap_or_default(),
+                host: host.unwrap_or_default(),
+                method: method.unwrap_or_default(),
+                status: status.unwrap_or_default(),
+                allow_external_paths,
+                external_path_root,
+            },
+        ),
 
         #[cfg(feature = "otel")]
         Commands::Otel {
@@ -641,16 +694,12 @@ pub fn run(cli: Cli) -> Result<()> {
                 match_mode: match_mode.unwrap_or(defaults.match_mode),
                 token: token.unwrap_or_else(|| defaults.token.clone()),
             };
-            if allow_external_paths {
-                run_redact_with_external_paths(
-                    database,
-                    &options,
-                    allow_external_paths,
-                    external_path_root.as_deref(),
-                )
-            } else {
-                run_redact(database, &options)
-            }
+            run_redact_input(
+                database,
+                &options,
+                allow_external_paths,
+                external_path_root.as_deref(),
+            )
         }
 
         Commands::Pii {
@@ -692,16 +741,12 @@ pub fn run(cli: Cli) -> Result<()> {
                     .unwrap_or_else(|| defaults.credit_card_regex.clone()),
                 token: token.unwrap_or_else(|| defaults.token.clone()),
             };
-            if allow_external_paths {
-                run_pii_with_external_paths(
-                    database,
-                    &options,
-                    allow_external_paths,
-                    external_path_root.as_deref(),
-                )
-            } else {
-                run_pii(database, &options)
-            }
+            run_pii_input(
+                database,
+                &options,
+                allow_external_paths,
+                external_path_root.as_deref(),
+            )
         }
 
         Commands::Diff {
@@ -712,6 +757,12 @@ pub fn run(cli: Cli) -> Result<()> {
             method,
             status,
             url_regex,
+            fail_on,
+            max_total_regression_ms,
+            max_ttfb_regression_ms,
+            max_response_size_increase,
+            max_new_errors,
+            ignore_query_param,
         } => {
             let defaults = &resolved.diff;
             let options = DiffOptions {
@@ -720,6 +771,15 @@ pub fn run(cli: Cli) -> Result<()> {
                 method: method.unwrap_or_else(|| defaults.method.clone()),
                 status: status.unwrap_or_else(|| defaults.status.clone()),
                 url_regex: url_regex.unwrap_or_else(|| defaults.url_regex.clone()),
+                fail_on: fail_on.unwrap_or_else(|| defaults.fail_on.clone()),
+                max_total_regression_ms: max_total_regression_ms
+                    .or(defaults.max_total_regression_ms),
+                max_ttfb_regression_ms: max_ttfb_regression_ms.or(defaults.max_ttfb_regression_ms),
+                max_response_size_increase: max_response_size_increase
+                    .or(defaults.max_response_size_increase),
+                max_new_errors: max_new_errors.or(defaults.max_new_errors),
+                ignore_query_params: ignore_query_param
+                    .unwrap_or_else(|| defaults.ignore_query_param.clone()),
             };
             run_diff(left, right, &options)
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1857,9 +1857,11 @@ fn test_redact_ignores_untrusted_external_blob_paths() {
         })
         .unwrap();
     let content: Vec<u8> = conn
-        .query_row("SELECT content FROM blobs WHERE hash='attacker'", [], |row| {
-            row.get(0)
-        })
+        .query_row(
+            "SELECT content FROM blobs WHERE hash='attacker'",
+            [],
+            |row| row.get(0),
+        )
         .unwrap();
     assert_eq!(hash, "attacker");
     assert!(content.is_empty());
@@ -1905,7 +1907,9 @@ fn test_pii_redaction_physically_removes_superseded_body() {
     assert_eq!(old_blob_count, 0);
     drop(conn);
     let raw = fs::read(&out_path).unwrap();
-    assert!(!raw.windows(secret.len()).any(|window| window == secret.as_bytes()));
+    assert!(!raw
+        .windows(secret.len())
+        .any(|window| window == secret.as_bytes()));
 }
 
 #[test]
@@ -3554,4 +3558,772 @@ fn test_redact_with_explicit_regex_patterns() {
         )
         .unwrap();
     assert_eq!(auth, "REDACTED");
+}
+
+#[test]
+fn test_check_validates_har_database_and_blob_hashes() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("check.db");
+    let warning_path = tmp.path().join("warning.har");
+
+    harlite()
+        .args(["check", "tests/fixtures/simple.har", "--strict"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Valid: yes"));
+
+    let mut warning_har: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/simple.har").unwrap()).unwrap();
+    warning_har["log"]
+        .as_object_mut()
+        .unwrap()
+        .remove("creator");
+    fs::write(&warning_path, serde_json::to_vec(&warning_har).unwrap()).unwrap();
+    harlite()
+        .arg("check")
+        .arg(&warning_path)
+        .args(["--strict", "--json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("\"valid\": false"))
+        .stderr(predicate::str::contains("issue(s)"));
+
+    let mut invalid_timing_har: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/simple.har").unwrap()).unwrap();
+    invalid_timing_har["log"]["entries"][0]["timings"]["wait"] = json!(-0.5);
+    fs::write(
+        &warning_path,
+        serde_json::to_vec(&invalid_timing_har).unwrap(),
+    )
+    .unwrap();
+    harlite()
+        .arg("check")
+        .arg(&warning_path)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "timing wait must be -1 or non-negative",
+        ));
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+    harlite()
+        .arg("check")
+        .arg(&db_path)
+        .args(["--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"valid\": true"));
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE response_body_fts SET body = 'stale indexed content' WHERE rowid = (SELECT MIN(rowid) FROM response_body_fts)",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+    harlite()
+        .arg("check")
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("does not match blob content"));
+    harlite()
+        .arg("fts-rebuild")
+        .arg(&db_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "INSERT INTO blobs (hash, content, size) VALUES ('not-a-blake3-hash', X'', 0)",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+    harlite()
+        .arg("check")
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("content hash is"));
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute("DELETE FROM blobs WHERE hash = 'not-a-blake3-hash'", [])
+        .unwrap();
+    conn.execute(
+        "UPDATE blobs SET content = X'636F7272757074' WHERE length(content) > 0",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    harlite()
+        .arg("check")
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Validation failed"));
+}
+
+#[test]
+fn test_stdin_har_support_for_import_check_export_and_report() {
+    let tmp = TempDir::new().unwrap();
+    let input = fs::read("tests/fixtures/simple.har").unwrap();
+    let db_path = tmp.path().join("stdin.db");
+    let exported_path = tmp.path().join("filtered.har");
+    let report_path = tmp.path().join("report.html");
+
+    harlite()
+        .args(["import", "-", "--output"])
+        .arg(&db_path)
+        .write_stdin(input.clone())
+        .assert()
+        .success();
+    harlite()
+        .args(["check", "-", "--strict"])
+        .write_stdin(input.clone())
+        .assert()
+        .success();
+    #[cfg(feature = "compression")]
+    {
+        let mut brotli_input = Vec::new();
+        {
+            let mut compressor = brotli::CompressorWriter::new(&mut brotli_input, 4096, 5, 22);
+            compressor.write_all(&input).unwrap();
+        }
+        harlite()
+            .args(["check", "-", "--strict"])
+            .write_stdin(brotli_input)
+            .assert()
+            .success();
+    }
+    harlite()
+        .args(["export", "-", "--output"])
+        .arg(&exported_path)
+        .write_stdin(input.clone())
+        .assert()
+        .success();
+    harlite()
+        .args(["report", "-", "--output"])
+        .arg(&report_path)
+        .write_stdin(input)
+        .assert()
+        .success();
+
+    assert!(db_path.exists());
+    assert!(exported_path.exists());
+    assert!(report_path.exists());
+}
+
+#[test]
+fn test_har_native_redaction_and_pii_redaction() {
+    let tmp = TempDir::new().unwrap();
+    let redact_out = tmp.path().join("safe.har");
+    let form_redact_out = tmp.path().join("form-safe.har");
+    let pii_input = tmp.path().join("pii.har");
+    let pii_out = tmp.path().join("pii-safe.har");
+    let encoded_pii_input = tmp.path().join("encoded-pii.har");
+    let encoded_pii_out = tmp.path().join("encoded-pii-safe.har");
+    let pii_db = tmp.path().join("pii.db");
+    let pii_db_out = tmp.path().join("pii-safe.db");
+    let relative_input = tmp.path().join("relative.har");
+    let relative_out = tmp.path().join("relative-safe.har");
+
+    harlite()
+        .args(["redact", "tests/fixtures/redact.har", "--output"])
+        .arg(&redact_out)
+        .assert()
+        .success();
+    let redacted: serde_json::Value =
+        serde_json::from_slice(&fs::read(&redact_out).unwrap()).unwrap();
+    assert_eq!(
+        redacted["log"]["entries"][0]["request"]["headers"][1]["value"],
+        "REDACTED"
+    );
+
+    let mut relative: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/redact.har").unwrap()).unwrap();
+    relative["log"]["entries"][0]["request"]["url"] = json!("/api?token=relative-url-secret");
+    relative["log"]["entries"][0]["request"]["queryString"] =
+        json!([{ "name": "token", "value": "relative-url-secret" }]);
+    fs::write(&relative_input, serde_json::to_vec(&relative).unwrap()).unwrap();
+    harlite()
+        .arg("redact")
+        .arg(&relative_input)
+        .args([
+            "--no-defaults",
+            "--query-param",
+            "token",
+            "--match",
+            "exact",
+            "--output",
+        ])
+        .arg(&relative_out)
+        .assert()
+        .success();
+    let relative_redacted: serde_json::Value =
+        serde_json::from_slice(&fs::read(&relative_out).unwrap()).unwrap();
+    assert_eq!(
+        relative_redacted["log"]["entries"][0]["request"]["url"],
+        "/api?token=REDACTED"
+    );
+    assert_eq!(
+        relative_redacted["log"]["entries"][0]["request"]["queryString"][0]["value"],
+        "REDACTED"
+    );
+
+    let mut pii: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/redact.har").unwrap()).unwrap();
+    let encoded_response = "contact=alice%40example.com";
+    pii["log"]["entries"][0]["response"]["content"]["mimeType"] =
+        json!("application/x-www-form-urlencoded");
+    pii["log"]["entries"][0]["response"]["content"]["encoding"] = json!("base64");
+    pii["log"]["entries"][0]["response"]["content"]["text"] =
+        json!(STANDARD.encode(encoded_response));
+    pii["log"]["entries"][0]["response"]["content"]["size"] = json!(encoded_response.len());
+    pii["log"]["entries"][0]["request"]["postData"] = json!({
+        "mimeType": "application/x-www-form-urlencoded",
+        "text": "contact=carol%40example.com",
+        "params": [{
+            "name": "erin@example.com",
+            "value": "bob@example.com",
+            "fileName": "frank@example.com.txt"
+        }]
+    });
+    fs::write(&pii_input, serde_json::to_vec(&pii).unwrap()).unwrap();
+
+    harlite()
+        .arg("redact")
+        .arg(&pii_input)
+        .args([
+            "--no-defaults",
+            "--body-regex",
+            r"[A-Za-z]+@example\.com",
+            "--output",
+        ])
+        .arg(&form_redact_out)
+        .assert()
+        .success();
+    let form_redacted = fs::read_to_string(&form_redact_out).unwrap();
+    assert!(!form_redacted.contains("bob@example.com"));
+    assert!(!form_redacted.contains("carol@example.com"));
+    assert!(!form_redacted.contains("erin@example.com"));
+    assert!(!form_redacted.contains("frank@example.com"));
+
+    harlite()
+        .arg("pii")
+        .arg(&pii_input)
+        .args(["--redact", "--output"])
+        .arg(&pii_out)
+        .args(["--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("email"));
+    let pii_redacted = fs::read_to_string(&pii_out).unwrap();
+    assert!(!pii_redacted.contains("alice@example.com"));
+    assert!(!pii_redacted.contains("bob@example.com"));
+    assert!(!pii_redacted.contains("carol@example.com"));
+    assert!(!pii_redacted.contains("carol%40example.com"));
+    assert!(!pii_redacted.contains("erin@example.com"));
+    assert!(!pii_redacted.contains("frank@example.com"));
+    assert!(pii_redacted.contains("REDACTED"));
+    let pii_redacted_json: serde_json::Value = serde_json::from_str(&pii_redacted).unwrap();
+    let response_text = pii_redacted_json["log"]["entries"][0]["response"]["content"]["text"]
+        .as_str()
+        .unwrap();
+    let response_text = String::from_utf8(STANDARD.decode(response_text).unwrap()).unwrap();
+    assert_eq!(response_text, "contact=REDACTED");
+
+    harlite().arg("check").arg(&pii_out).assert().success();
+
+    let mut encoded_pii: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/simple.har").unwrap()).unwrap();
+    encoded_pii["log"]["entries"][0]["request"]["url"] = json!(
+        "https://dave%40example.com@2125551212.example.test/users/bob%40example.com?email=alice%40example.com&nested=grace%2540example.com#carol%40example.com"
+    );
+    encoded_pii["log"]["entries"][0]["request"]["queryString"] =
+        json!([{ "name": "email", "value": "alice@example.com" }]);
+    fs::write(
+        &encoded_pii_input,
+        serde_json::to_vec(&encoded_pii).unwrap(),
+    )
+    .unwrap();
+    harlite()
+        .arg("pii")
+        .arg(&encoded_pii_input)
+        .args(["--redact", "--token", "[REDACTED]", "--output"])
+        .arg(&encoded_pii_out)
+        .args(["--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("email"));
+    let encoded_redacted = fs::read_to_string(&encoded_pii_out).unwrap();
+    assert!(!encoded_redacted.contains("alice@example.com"));
+    assert!(!encoded_redacted.contains("alice%40example.com"));
+    assert!(!encoded_redacted.contains("bob%40example.com"));
+    assert!(!encoded_redacted.contains("carol%40example.com"));
+    assert!(!encoded_redacted.contains("dave%40example.com"));
+    assert!(!encoded_redacted.contains("grace%2540example.com"));
+    assert!(!encoded_redacted.contains("grace%40example.com"));
+    assert!(!encoded_redacted.contains("2125551212"));
+    assert!(encoded_redacted.contains("REDACTED"));
+    let encoded_redacted_json: serde_json::Value = serde_json::from_str(&encoded_redacted).unwrap();
+    assert_eq!(
+        encoded_redacted_json["log"]["entries"][1]["request"]["url"],
+        encoded_pii["log"]["entries"][1]["request"]["url"]
+    );
+    assert_eq!(
+        encoded_redacted_json["log"]["entries"][1]["request"]["queryString"],
+        encoded_pii["log"]["entries"][1]["request"]["queryString"]
+    );
+
+    harlite()
+        .arg("import")
+        .arg(&pii_input)
+        .arg(&encoded_pii_input)
+        .args(["--bodies", "--output"])
+        .arg(&pii_db)
+        .assert()
+        .success();
+    harlite()
+        .arg("pii")
+        .arg(&pii_db)
+        .args(["--redact", "--output"])
+        .arg(&pii_db_out)
+        .args(["--format", "json"])
+        .assert()
+        .success();
+    let conn = rusqlite::Connection::open(&pii_db_out).unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT entries.url, entries.host, entries.path, entries.query_string, blobs.content
+             FROM entries
+             LEFT JOIN blobs ON blobs.hash = entries.request_body_hash",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<Vec<u8>>>(4)?,
+            ))
+        })
+        .unwrap();
+    let mut database_text = String::new();
+    for row in rows {
+        let (url, host, path, query, body) = row.unwrap();
+        database_text.push_str(&url.unwrap_or_default());
+        database_text.push_str(&host.unwrap_or_default());
+        database_text.push_str(&path.unwrap_or_default());
+        database_text.push_str(&query.unwrap_or_default());
+        database_text.push_str(&String::from_utf8(body.unwrap_or_default()).unwrap());
+    }
+    for secret in [
+        "alice@example.com",
+        "alice%40example.com",
+        "bob%40example.com",
+        "carol%40example.com",
+        "dave%40example.com",
+        "grace%2540example.com",
+        "grace%40example.com",
+        "2125551212",
+    ] {
+        assert!(
+            !database_text.contains(secret),
+            "database retained {secret}"
+        );
+    }
+}
+
+#[test]
+fn test_request_export_formats_and_sensitive_header_policy() {
+    let tmp = TempDir::new().unwrap();
+    let form_path = tmp.path().join("form.har");
+    let db_path = tmp.path().join("legacy.db");
+    let cookie_db_path = tmp.path().join("cookies.db");
+
+    harlite()
+        .args(["request", "tests/fixtures/redact.har", "--format", "curl"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("curl"))
+        .stdout(predicate::str::contains("supersecret").not());
+
+    harlite()
+        .args([
+            "request",
+            "tests/fixtures/redact.har",
+            "--format",
+            "powershell",
+            "--include-sensitive",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Invoke-WebRequest"))
+        .stdout(predicate::str::contains("supersecret"))
+        .stdout(predicate::str::contains("session_id=sess123"));
+
+    harlite()
+        .args([
+            "request",
+            "tests/fixtures/simple.har",
+            "--format",
+            "node-fetch",
+            "--limit",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "import fetch from \"node-fetch\";",
+        ));
+
+    let output = harlite()
+        .args([
+            "request",
+            "tests/fixtures/simple.har",
+            "--format",
+            "node-fetch",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(stdout.matches("import fetch from").count(), 1);
+
+    let mut form: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/simple.har").unwrap()).unwrap();
+    form["log"]["entries"][0]["request"]["method"] = json!("POST");
+    form["log"]["entries"][0]["request"]["postData"] = json!({
+        "mimeType": "application/x-www-form-urlencoded; charset=UTF-8",
+        "params": [{ "name": "message", "value": "hello world" }]
+    });
+    form["log"]["entries"][0]["request"]["headers"]
+        .as_array_mut()
+        .unwrap()
+        .extend([
+            json!({ "name": "Private-Token", "value": "gitlab-secret" }),
+            json!({ "name": "X-Amz-Security-Token", "value": "aws-secret" }),
+            json!({ "name": "X-Authorization", "value": "variant-secret" }),
+            json!({ "name": "X-AuthToken", "value": "concatenated-auth-secret" }),
+            json!({ "name": "X-AccessToken", "value": "concatenated-access-secret" }),
+            json!({ "name": "Transfer-Encoding", "value": "chunked" }),
+            json!({ "name": "X-Dupe", "value": "first" }),
+            json!({ "name": "x-dupe", "value": "second" }),
+        ]);
+    fs::write(&form_path, serde_json::to_vec(&form).unwrap()).unwrap();
+    harlite()
+        .arg("request")
+        .arg(&form_path)
+        .args(["--format", "curl", "--limit", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("message=hello+world"))
+        .stdout(predicate::str::contains(
+            "Content-Type: application/x-www-form-urlencoded; charset=UTF-8",
+        ))
+        .stdout(predicate::str::contains("gitlab-secret").not())
+        .stdout(predicate::str::contains("aws-secret").not())
+        .stdout(predicate::str::contains("variant-secret").not())
+        .stdout(predicate::str::contains("concatenated-auth-secret").not())
+        .stdout(predicate::str::contains("concatenated-access-secret").not())
+        .stdout(predicate::str::contains("Transfer-Encoding").not());
+
+    let output = harlite()
+        .arg("request")
+        .arg(&form_path)
+        .args(["--format", "powershell", "--limit", "1"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let powershell = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(
+        powershell.to_ascii_lowercase().matches("'x-dupe'").count(),
+        1
+    );
+    assert!(powershell.contains("first, second"));
+
+    form["log"]["entries"][0]["request"]["postData"] = json!({
+        "mimeType": "multipart/form-data",
+        "params": [
+            { "name": "message", "value": "hello multipart" },
+            {
+                "name": "upload",
+                "value": "captured file contents",
+                "fileName": "example.txt",
+                "contentType": "text/plain"
+            }
+        ]
+    });
+    form["log"]["entries"][0]["request"]["headers"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({
+            "name": "Content-Type",
+            "value": "multipart/form-data; boundary=stale-captured-boundary"
+        }));
+    fs::write(&form_path, serde_json::to_vec(&form).unwrap()).unwrap();
+    let output = harlite()
+        .arg("request")
+        .arg(&form_path)
+        .args(["--format", "fetch", "--limit", "1"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let fetch = String::from_utf8(output.stdout).unwrap();
+    assert!(fetch.contains("multipart/form-data; boundary=harlite-"));
+    assert!(!fetch.contains("stale-captured-boundary"));
+    assert!(fetch.contains("name=\\\"message\\\""));
+    assert!(fetch.contains("hello multipart"));
+    assert!(fetch.contains("filename=\\\"example.txt\\\""));
+    assert!(fetch.contains("captured file contents"));
+
+    form["log"]["entries"][0]["request"]["postData"] = json!({
+        "mimeType": "text/plain",
+        "text": "@captured-body"
+    });
+    fs::write(&form_path, serde_json::to_vec(&form).unwrap()).unwrap();
+    harlite()
+        .arg("request")
+        .arg(&form_path)
+        .args(["--format", "curl", "--limit", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("printf %s '@captured-body'"))
+        .stdout(predicate::str::contains("--data-binary @-"));
+
+    harlite()
+        .args(["import", "tests/fixtures/redact.har", "-o"])
+        .arg(&cookie_db_path)
+        .assert()
+        .success();
+    harlite()
+        .arg("request")
+        .arg(&cookie_db_path)
+        .args(["--include-sensitive", "--limit", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("session_id=sess123"));
+
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "--bodies", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+    harlite()
+        .arg("request")
+        .arg(&db_path)
+        .args([
+            "--method",
+            "get",
+            "--host",
+            "API.EXAMPLE.COM",
+            "--limit",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("curl"));
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_graphql_fields_entry_field;
+         DROP INDEX IF EXISTS idx_graphql_fields_field;
+         DROP INDEX IF EXISTS idx_graphql_fields_entry;
+         DROP TABLE graphql_fields;",
+    )
+    .unwrap();
+    drop(conn);
+    harlite()
+        .arg("request")
+        .arg(&db_path)
+        .args(["--limit", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("curl"));
+}
+
+#[test]
+fn test_analyze_and_diff_ci_gates_return_failure() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("gate.db");
+    let changed_db_path = tmp.path().join("gate-changed.db");
+    let noise_left_path = tmp.path().join("noise-left.har");
+    let noise_right_path = tmp.path().join("noise-right.har");
+    harlite()
+        .args(["import", "tests/fixtures/simple.har", "-o"])
+        .arg(&db_path)
+        .assert()
+        .success();
+    harlite()
+        .args(["import", "tests/fixtures/simple_changed.har", "-o"])
+        .arg(&changed_db_path)
+        .assert()
+        .success();
+
+    harlite()
+        .arg("analyze")
+        .arg(&db_path)
+        .args(["--max-p95-total-ms", "1", "--json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("\"entries\":2"))
+        .stderr(predicate::str::contains("Threshold exceeded"));
+
+    harlite()
+        .args([
+            "diff",
+            "tests/fixtures/simple.har",
+            "tests/fixtures/simple_changed.har",
+            "--fail-on",
+            "new-errors",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("\"change\""))
+        .stderr(predicate::str::contains("Threshold exceeded"));
+
+    harlite()
+        .arg("diff")
+        .arg(&db_path)
+        .arg(&changed_db_path)
+        .args([
+            "--method",
+            "get",
+            "--host",
+            "API.EXAMPLE.COM",
+            "--fail-on",
+            "any",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("\"change\""))
+        .stderr(predicate::str::contains("Threshold exceeded"));
+
+    harlite()
+        .arg("analyze")
+        .arg(&db_path)
+        .args(["--max-p95-total-ms", "NaN"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("finite and non-negative"));
+    harlite()
+        .args([
+            "diff",
+            "tests/fixtures/simple.har",
+            "tests/fixtures/simple_changed.har",
+            "--max-total-regression-ms",
+            "NaN",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("finite and non-negative"));
+
+    let noise_left: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/simple.har").unwrap()).unwrap();
+    let mut noise_right = noise_left.clone();
+    let original_time = noise_right["log"]["entries"][0]["time"].as_f64().unwrap();
+    noise_right["log"]["entries"][0]["time"] = json!(original_time + 1e-7);
+    noise_right["log"]["entries"][0]["response"]["headers"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({ "name": "x-noise-test", "value": "changed" }));
+    fs::write(&noise_left_path, serde_json::to_vec(&noise_left).unwrap()).unwrap();
+    fs::write(&noise_right_path, serde_json::to_vec(&noise_right).unwrap()).unwrap();
+    harlite()
+        .arg("diff")
+        .arg(&noise_left_path)
+        .arg(&noise_right_path)
+        .args([
+            "--fail-on",
+            "regression",
+            "--max-total-regression-ms",
+            "0",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"change\":\"changed\""));
+}
+
+#[test]
+fn test_diff_can_ignore_query_parameters_when_matching() {
+    let tmp = TempDir::new().unwrap();
+    let left_path = tmp.path().join("left.har");
+    let right_path = tmp.path().join("right.har");
+    let spelling_left_path = tmp.path().join("left-spelling.har");
+    let spelling_right_path = tmp.path().join("right-spelling.har");
+    let mut left: serde_json::Value =
+        serde_json::from_slice(&fs::read("tests/fixtures/simple.har").unwrap()).unwrap();
+    let mut right = left.clone();
+    for entry in left["log"]["entries"].as_array_mut().unwrap() {
+        let url = entry["request"]["url"].as_str().unwrap().to_string();
+        entry["request"]["url"] = json!(format!("{url}?cacheBust=left"));
+    }
+    for entry in right["log"]["entries"].as_array_mut().unwrap() {
+        let url = entry["request"]["url"].as_str().unwrap().to_string();
+        entry["request"]["url"] = json!(format!("{url}?cacheBust=right"));
+    }
+    fs::write(&left_path, serde_json::to_vec(&left).unwrap()).unwrap();
+    fs::write(&right_path, serde_json::to_vec(&right).unwrap()).unwrap();
+
+    let mut spelling_left = left.clone();
+    let mut spelling_right = right.clone();
+    spelling_left["log"]["entries"][0]["request"]["url"] =
+        json!("https://example.com?cacheBust=left");
+    spelling_right["log"]["entries"][0]["request"]["url"] =
+        json!("https://example.com/?cacheBust=right");
+    fs::write(
+        &spelling_left_path,
+        serde_json::to_vec(&spelling_left).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        &spelling_right_path,
+        serde_json::to_vec(&spelling_right).unwrap(),
+    )
+    .unwrap();
+
+    harlite()
+        .arg("diff")
+        .arg(&left_path)
+        .arg(&right_path)
+        .args([
+            "--ignore-query-param",
+            "cacheBust",
+            "--fail-on",
+            "any",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+
+    harlite()
+        .arg("diff")
+        .arg(&spelling_left_path)
+        .arg(&spelling_right_path)
+        .args([
+            "--ignore-query-param",
+            "cacheBust",
+            "--fail-on",
+            "any",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Threshold exceeded"));
 }


### PR DESCRIPTION
## Summary

- ship prebuilt Linux AMD64/ARM64, macOS AMD64/ARM64, and Windows AMD64 archives with SHA-256 checksums and Sigstore-backed GitHub artifact attestations
- add `harlite check`, stdin HAR support, HAR/database redaction and PII handling, and cURL/Fetch/node-fetch/PowerShell request export
- add analyze/diff CI regression gates, atomic output hardening, expanded validation, release notes, and pinned CI/release actions
- bump the crate to 0.4.0 and prepare crates.io packaging

## Verification

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --no-default-features --locked`
- `cargo test --lib --no-default-features --locked`
- `cargo +1.85.0 check --all-features --locked`
- `cargo package --allow-dirty --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `cargo audit`
- nine recursive local Codex review passes; final pass reported no actionable findings

Closes #126